### PR TITLE
Updates OLED to 3-line display for xfade status

### DIFF
--- a/STM32CubeIDE/JUMBLEQ/Appli/Core/Inc/ui_control.h
+++ b/STM32CubeIDE/JUMBLEQ/Appli/Core/Inc/ui_control.h
@@ -27,6 +27,8 @@ int16_t get_current_ch1_db(void);
 int16_t get_current_ch2_db(void);
 int16_t get_current_master_db(void);
 int16_t get_current_dry_wet(void);
+uint8_t get_current_xfade2_cc_value(void); // same value as send_control_change for xfade[2]
+uint8_t get_current_xfade3_cc_value(void); // same value as send_control_change for xfade[3]
 char* get_current_input_typeA_str(void);
 char* get_current_input_typeB_str(void);
 char* get_current_input_srcA_str(void);

--- a/STM32CubeIDE/JUMBLEQ/Appli/Core/Src/oled_control.c
+++ b/STM32CubeIDE/JUMBLEQ/Appli/Core/Src/oled_control.c
@@ -169,10 +169,14 @@ void OLED_UpdateTask(void)
     char line1_mst[16];
     char line2_c1[16];
     char line2_dw[16];
+    char line3_x3[16];
+    char line3_x2[16];
     static char prev_line1_ch2[16] = {0};
     static char prev_line1_mst[16] = {0};
     static char prev_line2_c1[16]  = {0};
     static char prev_line2_dw[16]  = {0};
+    static char prev_line3_x3[16]  = {0};
+    static char prev_line3_x2[16]  = {0};
     static char prev_srcA[32]      = {0};
     static char prev_srcB[32]      = {0};
     static char prev_typeA[32]     = {0};
@@ -189,21 +193,27 @@ void OLED_UpdateTask(void)
 
     const uint8_t line1_ch2_x = 0;
     const uint8_t line1_mst_x = 64;
-    const uint8_t line1_y     = 4;
+    const uint8_t line1_y     = 0;
 
     snprintf(line1_ch2, sizeof(line1_ch2), "C2:%3ddB", get_current_ch2_db());
     snprintf(line1_mst, sizeof(line1_mst), "Mst:%3ddB", get_current_master_db());
     const uint8_t line2_c1_x = 0;
     const uint8_t line2_dw_x = 64;
-    const uint8_t line2_y    = 18;
+    const uint8_t line2_y    = 11;
 
     snprintf(line2_c1, sizeof(line2_c1), "C1:%3ddB", get_current_ch1_db());
     snprintf(line2_dw, sizeof(line2_dw), "D/W:%3d%%", get_current_dry_wet());
+    uint8_t x2 = get_current_xfade2_cc_value();
+    uint8_t x3 = get_current_xfade3_cc_value();
+    snprintf(line3_x3, sizeof(line3_x3), "X3:%3u", x3);
+    snprintf(line3_x2, sizeof(line3_x2), "X2:%3u", x2);
 
-    update_main_text_block(prev_line1_ch2, sizeof(prev_line1_ch2), line1_ch2, 0, line1_y, 63, line1_y + 10, line1_ch2_x, line1_y, 0, 1, &dirty, &dirty_start_page, &dirty_end_page);
-    update_main_text_block(prev_line1_mst, sizeof(prev_line1_mst), line1_mst, 64, line1_y, 127, line1_y + 10, line1_mst_x, line1_y, 0, 1, &dirty, &dirty_start_page, &dirty_end_page);
-    update_main_text_block(prev_line2_c1, sizeof(prev_line2_c1), line2_c1, 0, line2_y, 63, line2_y + 10, line2_c1_x, line2_y, 2, 3, &dirty, &dirty_start_page, &dirty_end_page);
-    update_main_text_block(prev_line2_dw, sizeof(prev_line2_dw), line2_dw, 64, line2_y, 127, line2_y + 10, line2_dw_x, line2_y, 2, 3, &dirty, &dirty_start_page, &dirty_end_page);
+    update_main_text_block(prev_line1_ch2, sizeof(prev_line1_ch2), line1_ch2, 0, 0, 63, 10, line1_ch2_x, line1_y, 0, 1, &dirty, &dirty_start_page, &dirty_end_page);
+    update_main_text_block(prev_line1_mst, sizeof(prev_line1_mst), line1_mst, 64, 0, 127, 10, line1_mst_x, line1_y, 0, 1, &dirty, &dirty_start_page, &dirty_end_page);
+    update_main_text_block(prev_line2_c1, sizeof(prev_line2_c1), line2_c1, 0, 11, 63, 21, line2_c1_x, line2_y, 1, 2, &dirty, &dirty_start_page, &dirty_end_page);
+    update_main_text_block(prev_line2_dw, sizeof(prev_line2_dw), line2_dw, 64, 11, 127, 21, line2_dw_x, line2_y, 1, 2, &dirty, &dirty_start_page, &dirty_end_page);
+    update_main_text_block(prev_line3_x3, sizeof(prev_line3_x3), line3_x3, 0, 22, 63, 31, 0, 22, 2, 3, &dirty, &dirty_start_page, &dirty_end_page);
+    update_main_text_block(prev_line3_x2, sizeof(prev_line3_x2), line3_x2, 64, 22, 127, 31, 71, 22, 2, 3, &dirty, &dirty_start_page, &dirty_end_page);
 
     if (dirty)
     {

--- a/STM32CubeIDE/JUMBLEQ/Appli/Core/Src/ui_control.c
+++ b/STM32CubeIDE/JUMBLEQ/Appli/Core/Src/ui_control.c
@@ -86,6 +86,20 @@ static void send_control_change(uint8_t number, uint8_t value, uint8_t channel)
     tud_midi_stream_write(0, control_change, 3);
 }
 
+static uint8_t xfade_to_cc(float xfade)
+{
+    if (xfade < 0.0f)
+    {
+        xfade = 0.0f;
+    }
+    else if (xfade > 1.0f)
+    {
+        xfade = 1.0f;
+    }
+
+    return (uint8_t) (127.0f - xfade * 127.0f);
+}
+
 uint8_t get_current_xfA_position(void)
 {
     return s_ui.current_xfA_position;
@@ -123,6 +137,16 @@ int16_t get_current_dry_wet(void)
         pct = 100;
     }
     return pct;
+}
+
+uint8_t get_current_xfade2_cc_value(void)
+{
+    return xfade_to_cc(s_ui.xfade[2]);
+}
+
+uint8_t get_current_xfade3_cc_value(void)
+{
+    return xfade_to_cc(s_ui.xfade[3]);
 }
 
 char* get_current_input_typeA_str(void)
@@ -651,7 +675,7 @@ static void ui_control_apply_xfade_updates(void)
     {
         if (fabs(s_ui.xfade[i] - s_ui.xfade_prev[i]) > 0.01f)
         {
-            send_control_change(10 + (5 - i), (uint8_t) (127.0f - s_ui.xfade[i] * 127.0f), 0);
+            send_control_change(10 + (5 - i), xfade_to_cc(s_ui.xfade[i]), 0);
 
             if (i == 0 || i == 1)
             {


### PR DESCRIPTION
Introduces a third line of information on the main OLED display.

*   Displays the current values for crossfades 2 and 3, representing the state of the central magnetic switches.
*   Adjusts the existing OLED layout to accommodate the new line of data.
*   Adds utility functions to retrieve these crossfade values in MIDI CC format.
*   Implements a reusable helper function to consistently convert float crossfade values to `uint8_t` MIDI CC values (0-127), improving code clarity and maintainability.