### PR TITLE
Phono選択時のゲイン調整をフォノEQ前のアナログ段で行う

### DIFF
--- a/STM32CubeIDE/JUMBLEQ/Appli/Core/Inc/ak4619.h
+++ b/STM32CubeIDE/JUMBLEQ/Appli/Core/Inc/ak4619.h
@@ -10,6 +10,13 @@
 
 #include "main.h"
 
+#define AK4619_MIC_GAIN_CH1   0U
+#define AK4619_MIC_GAIN_CH2   1U
+#define AK4619_MIC_GAIN_DB_0  0U
+#define AK4619_MIC_GAIN_DB_27 27U
+
 void AUDIO_Init_AK4619(uint32_t hz);
+
+void AUDIO_Mic_Gain_AMP_Setting_Channel(uint8_t ch, uint8_t gain_db);
 
 #endif /* INC_AK4619_H_ */

--- a/STM32CubeIDE/JUMBLEQ/Appli/Core/Src/ak4619.c
+++ b/STM32CubeIDE/JUMBLEQ/Appli/Core/Src/ak4619.c
@@ -12,6 +12,11 @@
 
 extern osMutexId_t i2cMutexHandle;
 
+#define AK4619_REG_MIC_AMP_GAIN_ADC1 0x04U
+#define AK4619_REG_MIC_AMP_GAIN_ADC2 0x05U
+#define AK4619_MIC_GAIN_BITS_0DB     0x02U
+#define AK4619_MIC_GAIN_BITS_27DB    0x0BU
+
 static HAL_StatusTypeDef ak4619_write_reg(uint8_t reg, uint8_t value)
 {
     HAL_StatusTypeDef status = HAL_ERROR;
@@ -43,6 +48,13 @@ static HAL_StatusTypeDef ak4619_write_reg(uint8_t reg, uint8_t value)
     }
 
     return status;
+}
+
+static HAL_StatusTypeDef ak4619_write_mic_gain_reg(uint8_t reg, uint8_t gain_bits)
+{
+    const uint8_t value = (uint8_t)((gain_bits << 4) | gain_bits);
+
+    return ak4619_write_reg(reg, value);
 }
 
 void AUDIO_Init_AK4619(uint32_t hz)
@@ -138,4 +150,36 @@ void AUDIO_Init_AK4619(uint32_t hz)
     // Power Management
     (void) ak4619_write_reg(0x00, 0x37);  // 00 11 0 11 1
     // HAL_I2C_Mem_Read(&hi2c3, (0b0010001 << 1) | 1, 0x00, I2C_MEMADD_SIZE_8BIT, rcvData, sizeof(rcvData), 10000);
+}
+
+void AUDIO_Mic_Gain_AMP_Setting_Channel(uint8_t ch, uint8_t gain_db)
+{
+    uint8_t reg;
+    uint8_t gain_bits;
+
+    switch (ch)
+    {
+    case AK4619_MIC_GAIN_CH1:
+        reg = AK4619_REG_MIC_AMP_GAIN_ADC1;
+        break;
+    case AK4619_MIC_GAIN_CH2:
+        reg = AK4619_REG_MIC_AMP_GAIN_ADC2;
+        break;
+    default:
+        return;
+    }
+
+    switch (gain_db)
+    {
+    case AK4619_MIC_GAIN_DB_0:
+        gain_bits = AK4619_MIC_GAIN_BITS_0DB;
+        break;
+    case AK4619_MIC_GAIN_DB_27:
+        gain_bits = AK4619_MIC_GAIN_BITS_27DB;
+        break;
+    default:
+        return;
+    }
+
+    (void)ak4619_write_mic_gain_reg(reg, gain_bits);
 }

--- a/STM32CubeIDE/JUMBLEQ/Appli/Core/Src/ui_control.c
+++ b/STM32CubeIDE/JUMBLEQ/Appli/Core/Src/ui_control.c
@@ -12,6 +12,7 @@
 #include "eeprom.h"
 #include "hpdma.h"
 #include "i2c.h"
+#include "ak4619.h"
 #include "led_control.h"
 #include "linked_list.h"
 
@@ -816,11 +817,45 @@ static void replace_assign_for_input_channel(uint8_t* assign, uint8_t input_ch, 
     }
 }
 
+static void apply_mic_gain_amp_setting(uint8_t input_ch, uint8_t input_type)
+{
+    uint8_t codec_ch;
+    uint8_t gain_db;
+
+    switch (input_ch)
+    {
+    case INPUT_CH1:
+        codec_ch = AK4619_MIC_GAIN_CH1;
+        break;
+    case INPUT_CH2:
+        codec_ch = AK4619_MIC_GAIN_CH2;
+        break;
+    default:
+        return;
+    }
+
+    switch (input_type)
+    {
+    case INPUT_TYPE_LINE:
+        gain_db = AK4619_MIC_GAIN_DB_0;
+        break;
+    case INPUT_TYPE_PHONO:
+        gain_db = AK4619_MIC_GAIN_DB_27;
+        break;
+    default:
+        return;
+    }
+
+    AUDIO_Mic_Gain_AMP_Setting_Channel(codec_ch, gain_db);
+}
+
 static void apply_input_type_change(uint8_t input_ch, uint8_t input_type)
 {
     const uint8_t new_src = input_src_from_channel_type(input_ch, input_type);
 
     select_input_type(input_ch, input_type);
+    apply_mic_gain_amp_setting(input_ch, input_type);
+
     if (input_ch == INPUT_CH1)
     {
         s_ui.current_ch1_input_type = input_type;


### PR DESCRIPTION
- AK4619のMIC Gain AMP Settingレジスタを使い、アナログ段でゲインを稼ぐ
