### PR TITLE
デュアルfade-downのリトリガー処理を実装

### DIFF
--- a/STM32CubeIDE/JUMBLEQ/Appli/Core/Inc/eeprom.h
+++ b/STM32CubeIDE/JUMBLEQ/Appli/Core/Inc/eeprom.h
@@ -28,8 +28,8 @@ typedef struct
     uint8_t current_ch1_dvs_enable;
     uint8_t current_ch2_dvs_enable;
     uint8_t mag_output_mode_flags;
-    float current_xf_curve_exp_a;
-    float current_xf_curve_exp_b;
+    float current_xfade_cut_margin_a;
+    float current_xfade_cut_margin_b;
 } EEPROM_DeviceConfig_t;
 
 #define EEPROM_CONFIG_ADDR               (0x0000U)

--- a/STM32CubeIDE/JUMBLEQ/Appli/Core/Inc/ui_control.h
+++ b/STM32CubeIDE/JUMBLEQ/Appli/Core/Inc/ui_control.h
@@ -24,12 +24,12 @@ typedef struct
     uint8_t current_ch1_dvs_enable;
     uint8_t current_ch2_dvs_enable;
     bool  mag_out_as_note;
-    float current_xf_curve_exp_a;
-    float current_xf_curve_exp_b;
+    float current_xfade_cut_margin_a;
+    float current_xfade_cut_margin_b;
 } UI_ControlPersistState_t;
 
-#define UI_XFADE_CURVE_EXP_A_DEFAULT (0.5f)
-#define UI_XFADE_CURVE_EXP_B_DEFAULT (50.0f)
+#define UI_XFADE_CUT_MARGIN_A_DEFAULT (0.45f)
+#define UI_XFADE_CUT_MARGIN_B_DEFAULT (0.16f)
 
 uint8_t get_current_xfA_position(void);
 uint8_t get_current_xfB_position(void);
@@ -54,10 +54,10 @@ uint8_t get_current_input_srcB_channel(void);  // 0:none, 1:CH1, 2:CH2
 bool get_current_ch1_dvs_enabled(void);
 bool get_current_ch2_dvs_enabled(void);
 bool ui_control_is_curve_edit_mode_enabled(void);
-float ui_control_get_curve_exp_a(void);
-float ui_control_get_curve_exp_b(void);
-uint8_t ui_control_get_curve_exp_a_cc(void);
-uint8_t ui_control_get_curve_exp_b_cc(void);
+float ui_control_get_xfade_cut_margin_a(void);
+float ui_control_get_xfade_cut_margin_b(void);
+uint8_t ui_control_get_xfade_cut_margin_a_cc(void);
+uint8_t ui_control_get_xfade_cut_margin_b_cc(void);
 
 void start_adc(void);
 void ui_control_task(void);

--- a/STM32CubeIDE/JUMBLEQ/Appli/Core/Src/audio_control.c
+++ b/STM32CubeIDE/JUMBLEQ/Appli/Core/Src/audio_control.c
@@ -204,13 +204,13 @@ void AUDIO_LoadAndApplyRoutingFromEEPROM(void)
         ui_state.current_ch1_dvs_enable = cfg.current_ch1_dvs_enable;
         ui_state.current_ch2_dvs_enable = cfg.current_ch2_dvs_enable;
         ui_state.mag_out_as_note = (cfg.mag_output_mode_flags & EEPROM_CFG_FLAG_MAG_OUT_AS_NOTE) != 0U;
-        ui_state.current_xf_curve_exp_a = cfg.current_xf_curve_exp_a;
-        ui_state.current_xf_curve_exp_b = cfg.current_xf_curve_exp_b;
+        ui_state.current_xfade_cut_margin_a = cfg.current_xfade_cut_margin_a;
+        ui_state.current_xfade_cut_margin_b = cfg.current_xfade_cut_margin_b;
 
         if (ui_control_apply_persist_state(&ui_state))
         {
             SEGGER_RTT_printf(0,
-                              "EEPROM routing applied: CH1=%u CH2=%u XFA=%u XFB=%u XFP=%u RTN=%u HP=%u DVS1=%u DVS2=%u CURVE_A=%.4f CURVE_B=%.4f\r\n",
+                              "EEPROM routing applied: CH1=%u CH2=%u XFA=%u XFB=%u XFP=%u RTN=%u HP=%u DVS1=%u DVS2=%u CUT_MARGIN_A=%.4f CUT_MARGIN_B=%.4f\r\n",
                               (unsigned)cfg.current_ch1_input_type,
                               (unsigned)cfg.current_ch2_input_type,
                               (unsigned)cfg.current_xfA_assign,
@@ -220,8 +220,8 @@ void AUDIO_LoadAndApplyRoutingFromEEPROM(void)
                               (unsigned)cfg.current_hp_out_source,
                               (unsigned)cfg.current_ch1_dvs_enable,
                               (unsigned)cfg.current_ch2_dvs_enable,
-                              (double)cfg.current_xf_curve_exp_a,
-                              (double)cfg.current_xf_curve_exp_b);
+                              (double)cfg.current_xfade_cut_margin_a,
+                              (double)cfg.current_xfade_cut_margin_b);
         }
         else
         {
@@ -241,8 +241,8 @@ void AUDIO_LoadAndApplyRoutingFromEEPROM(void)
         ui_state.current_ch1_dvs_enable = cfg.current_ch1_dvs_enable;
         ui_state.current_ch2_dvs_enable = cfg.current_ch2_dvs_enable;
         ui_state.mag_out_as_note = (cfg.mag_output_mode_flags & EEPROM_CFG_FLAG_MAG_OUT_AS_NOTE) != 0U;
-        ui_state.current_xf_curve_exp_a = cfg.current_xf_curve_exp_a;
-        ui_state.current_xf_curve_exp_b = cfg.current_xf_curve_exp_b;
+        ui_state.current_xfade_cut_margin_a = cfg.current_xfade_cut_margin_a;
+        ui_state.current_xfade_cut_margin_b = cfg.current_xfade_cut_margin_b;
         (void)ui_control_apply_persist_state(&ui_state);
 
         if (EEPROM_SaveConfig(&hi2c2, &cfg) == HAL_OK)

--- a/STM32CubeIDE/JUMBLEQ/Appli/Core/Src/eeprom.c
+++ b/STM32CubeIDE/JUMBLEQ/Appli/Core/Src/eeprom.c
@@ -63,8 +63,8 @@ void EEPROM_ConfigSetDefaults(EEPROM_DeviceConfig_t* cfg)
     cfg->current_ch1_dvs_enable = 0U; /* disabled */
     cfg->current_ch2_dvs_enable = 0U; /* disabled */
     cfg->mag_output_mode_flags  = 0U;
-    cfg->current_xf_curve_exp_a = UI_XFADE_CURVE_EXP_A_DEFAULT;
-    cfg->current_xf_curve_exp_b = UI_XFADE_CURVE_EXP_B_DEFAULT;
+    cfg->current_xfade_cut_margin_a = UI_XFADE_CUT_MARGIN_A_DEFAULT;
+    cfg->current_xfade_cut_margin_b = UI_XFADE_CUT_MARGIN_B_DEFAULT;
 }
 
 void EEPROM_ConfigCaptureCurrent(EEPROM_DeviceConfig_t* cfg)
@@ -87,8 +87,8 @@ void EEPROM_ConfigCaptureCurrent(EEPROM_DeviceConfig_t* cfg)
     cfg->current_ch1_dvs_enable = state.current_ch1_dvs_enable;
     cfg->current_ch2_dvs_enable = state.current_ch2_dvs_enable;
     cfg->mag_output_mode_flags  = state.mag_out_as_note ? EEPROM_CFG_FLAG_MAG_OUT_AS_NOTE : 0U;
-    cfg->current_xf_curve_exp_a = state.current_xf_curve_exp_a;
-    cfg->current_xf_curve_exp_b = state.current_xf_curve_exp_b;
+    cfg->current_xfade_cut_margin_a = state.current_xfade_cut_margin_a;
+    cfg->current_xfade_cut_margin_b = state.current_xfade_cut_margin_b;
 }
 
 HAL_StatusTypeDef EEPROM_CheckConnection(I2C_HandleTypeDef* hi2c)

--- a/STM32CubeIDE/JUMBLEQ/Appli/Core/Src/oled_control.c
+++ b/STM32CubeIDE/JUMBLEQ/Appli/Core/Src/oled_control.c
@@ -315,8 +315,8 @@ void OLED_UpdateTask(void)
     {
         bool main_redraw = dirty;
         snprintf(line_edit_mode, sizeof(line_edit_mode), "CURVE EDIT [ON]");
-        snprintf(line_edit_a, sizeof(line_edit_a), "A:%5.2f CC%3u", (double) ui_control_get_curve_exp_a(), (unsigned) ui_control_get_curve_exp_a_cc());
-        snprintf(line_edit_b, sizeof(line_edit_b), "B:%5.2f CC%3u", (double) ui_control_get_curve_exp_b(), (unsigned) ui_control_get_curve_exp_b_cc());
+        snprintf(line_edit_a, sizeof(line_edit_a), "A:%5.2f CC%3u", (double) ui_control_get_xfade_cut_margin_a(), (unsigned) ui_control_get_xfade_cut_margin_a_cc());
+        snprintf(line_edit_b, sizeof(line_edit_b), "B:%5.2f CC%3u", (double) ui_control_get_xfade_cut_margin_b(), (unsigned) ui_control_get_xfade_cut_margin_b_cc());
 
         if ((strcmp(prev_line_edit_mode, line_edit_mode) != 0) ||
             (strcmp(prev_line_edit_a, line_edit_a) != 0) ||

--- a/STM32CubeIDE/JUMBLEQ/Appli/Core/Src/ui_control.c
+++ b/STM32CubeIDE/JUMBLEQ/Appli/Core/Src/ui_control.c
@@ -1691,16 +1691,13 @@ static float clamp01(float value)
 
 static float compute_xfade_pair_threshold_ramp(float value, float threshold, float width)
 {
-    float t;
-    float smootherstep;
-
     if (width <= 0.0f)
     {
         return (value >= threshold) ? 1.0f : 0.0f;
     }
 
-    t = clamp01((value - threshold) / width);
-    smootherstep = t * t * t * (t * ((t * 6.0f) - 15.0f) + 10.0f);
+    const float t = clamp01((value - threshold) / width);
+    const float smootherstep = t * t * t * (t * ((t * 6.0f) - 15.0f) + 10.0f);
     return (XFADE_PAIR_RAMP_LINEAR_BLEND * t) + ((1.0f - XFADE_PAIR_RAMP_LINEAR_BLEND) * smootherstep);
 }
 

--- a/STM32CubeIDE/JUMBLEQ/Appli/Core/Src/ui_control.c
+++ b/STM32CubeIDE/JUMBLEQ/Appli/Core/Src/ui_control.c
@@ -1722,8 +1722,8 @@ static float compute_xfade_pair_value(const xfade_pair_runtime_t* pair)
     // - releasing either side leaves the held output where it was
     // - pushing fade-down into the bottom zone forces the held output to 0
     const float xfade_cut_margin = (pair->prev_idx == XFADE_PAIR_A) ? s_ui.xfade_cut_margin_a : s_ui.xfade_cut_margin_b;
-    const float fade_up_raw      = get_xfade_pair_fade_up_raw(pair);
     const float margin           = clamp_xfade_cut_margin(xfade_cut_margin);
+    const float fade_up          = get_xfade_pair_fade_up_raw(pair);
     const float fade_down        = get_xfade_pair_fade_down_raw(pair);
     // fade-up opens across the first margin-wide slice of travel after onset deadband.
     const float up_open_threshold             = 0.0f;
@@ -1735,15 +1735,13 @@ static float compute_xfade_pair_value(const xfade_pair_runtime_t* pair)
     const float down_bottom_release_threshold = margin;
     bool bottomed           = s_ui.xf.pair_fade_down_bottomed[pair->prev_idx];
     float hold_value        = s_ui.xf.pair_hold_value[pair->prev_idx];
-    const float up_gain     = compute_xfade_pair_threshold_ramp(fade_up_raw, up_open_threshold, margin);
+    const float up_gain     = compute_xfade_pair_threshold_ramp(fade_up, up_open_threshold, margin);
     const float down_gain   = compute_xfade_pair_threshold_ramp(fade_down, down_press_threshold, margin);
-    float output            = hold_value;
 
     if (fade_down <= down_bottom_threshold)
     {
         bottomed   = true;
         hold_value = 0.0f;
-        output     = 0.0f;
     }
     else
     {
@@ -1760,13 +1758,11 @@ static float compute_xfade_pair_value(const xfade_pair_runtime_t* pair)
         {
             hold_value = down_gain;
         }
-
-        output = hold_value;
     }
 
     s_ui.xf.pair_hold_value[pair->prev_idx]         = hold_value;
     s_ui.xf.pair_fade_down_bottomed[pair->prev_idx] = bottomed;
-    return output;
+    return hold_value;
 }
 
 // Compute and commit one pair output (A or B) from the current fade-up/fade-down drive values.

--- a/STM32CubeIDE/JUMBLEQ/Appli/Core/Src/ui_control.c
+++ b/STM32CubeIDE/JUMBLEQ/Appli/Core/Src/ui_control.c
@@ -77,8 +77,11 @@ typedef struct
     float down_floor[MAG_SW_NUM];  // Per-sensor held minimum used by paired fade-down tracking.
     float up_peak[MAG_SW_NUM];  // Per-sensor held maximum used by paired fade-up tracking.
     float pair_hold_value[2];  // Current held output value for each xfade pair.
+    float pair_bottom_restore_value[2];  // Held output value to restore after leaving the fade-down bottom.
     float fade_up_prev[2];  // Previous fade-up value used to detect when pair output needs recomputing.
     float fade_down_prev[2];  // Previous fade-down value used to detect when pair output needs recomputing.
+    bool pair_fade_down_cut_active[2];  // Whether each pair is inside the current fade-down cut gesture.
+    bool pair_bottom_hold_active[2];  // Whether each pair is still forced muted at the bottom of a fade-down gesture.
     bool pair_fade_down_bottomed[2];  // Whether each pair is currently in the fade-down bottom zone.
     bool fade_prev_valid;  // Whether the previous pair fade values have been initialized.
     uint8_t note_peak_vel[MAG_SW_NUM];  // Peak velocity captured while scanning one xfade sensor note-on edge.
@@ -148,8 +151,11 @@ static ui_control_state_t s_ui = {
     .xf.down_floor          = {1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f},
     .xf.up_peak             = {0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f},
     .xf.pair_hold_value          = {0.0f, 0.0f},
+    .xf.pair_bottom_restore_value = {0.0f, 0.0f},
     .xf.fade_up_prev             = {0.0f, 0.0f},
     .xf.fade_down_prev           = {1.0f, 1.0f},
+    .xf.pair_fade_down_cut_active = {false, false},
+    .xf.pair_bottom_hold_active  = {false, false},
     .xf.pair_fade_down_bottomed  = {false, false},
     .xf.fade_prev_valid          = false,
     .is_start_audio_control = false,
@@ -168,6 +174,8 @@ static const float XFADE_PAIR_ONSET_DEADBAND    = 0.05f;
 static const float XFADE_PAIR_CUT_MARGIN_MIN    = 0.04f;
 static const float XFADE_PAIR_CUT_MARGIN_MAX    = 0.45f;
 static const float XFADE_PAIR_RAMP_LINEAR_BLEND = 0.60f;
+static const float XFADE_PAIR_BOTTOM_HOLD_RELEASE_RATIO = 0.125f;
+static const float XFADE_PAIR_BOTTOM_REHOLD_RATIO       = 0.04f;
 
 static const uint8_t MIDI_CH_15                  = 14U;  // zero-based MIDI channel index.
 static const uint8_t MIDI_CC_XFADE_CUT_MARGIN_A  = 20U;
@@ -1728,23 +1736,61 @@ static float compute_xfade_pair_value(const xfade_pair_runtime_t* pair)
     const float down_press_threshold           = 1.0f - margin;
     // "Bottomed" means the fade-down side reached near-bottom during the current gesture.
     const float down_bottom_threshold       = margin * 0.5f;
-    // After bottoming out, ignore further fade-down cuts until the sensor has moved back out of the bottom zone.
-    const float down_bottom_release_threshold = margin;
+    const float down_bottom_hold_release_threshold = margin * XFADE_PAIR_BOTTOM_HOLD_RELEASE_RATIO;
+    const float down_bottom_rehold_threshold       = margin * XFADE_PAIR_BOTTOM_REHOLD_RATIO;
+    // After bottoming out, ignore further fade-down cuts until the sensor returns to unpressed.
+    const float down_bottom_release_threshold = 1.0f;
+    bool cut_active         = s_ui.xf.pair_fade_down_cut_active[pair->prev_idx];
+    bool bottom_hold_active = s_ui.xf.pair_bottom_hold_active[pair->prev_idx];
     bool bottomed           = s_ui.xf.pair_fade_down_bottomed[pair->prev_idx];
+    bool bottom_entered     = false;
     float hold_value        = s_ui.xf.pair_hold_value[pair->prev_idx];
+    float restore_value     = s_ui.xf.pair_bottom_restore_value[pair->prev_idx];
     const float up_gain     = compute_xfade_pair_threshold_ramp(fade_up, up_open_threshold, margin);
     const float down_gain   = compute_xfade_pair_threshold_ramp(fade_down, down_press_threshold, margin);
 
-    if (fade_down <= down_bottom_threshold)
+    if (!cut_active && (fade_down <= down_press_threshold))
     {
-        bottomed   = true;
-        hold_value = 0.0f;
+        cut_active    = true;
+        restore_value = hold_value;
     }
-    else
+
+    if (!bottomed && (fade_down <= down_bottom_threshold))
+    {
+        bottomed           = true;
+        bottom_hold_active = true;
+        bottom_entered     = true;
+        hold_value         = 0.0f;
+    }
+
+    if (bottom_hold_active)
+    {
+        if (!bottom_entered && (fade_down >= down_bottom_hold_release_threshold))
+        {
+            bottom_hold_active = false;
+            if (restore_value > hold_value)
+            {
+                hold_value = restore_value;
+            }
+        }
+        else
+        {
+            hold_value = 0.0f;
+        }
+    }
+    else if (bottomed && (fade_down <= down_bottom_rehold_threshold))
+    {
+        bottom_hold_active = true;
+        hold_value         = 0.0f;
+    }
+
+    if (!bottom_hold_active)
     {
         if (bottomed && (fade_down >= down_bottom_release_threshold))
         {
-            bottomed = false;
+            bottomed           = false;
+            bottom_hold_active = false;
+            cut_active         = false;
         }
 
         if (up_gain > hold_value)
@@ -1758,6 +1804,9 @@ static float compute_xfade_pair_value(const xfade_pair_runtime_t* pair)
     }
 
     s_ui.xf.pair_hold_value[pair->prev_idx]         = hold_value;
+    s_ui.xf.pair_bottom_restore_value[pair->prev_idx] = restore_value;
+    s_ui.xf.pair_fade_down_cut_active[pair->prev_idx] = cut_active;
+    s_ui.xf.pair_bottom_hold_active[pair->prev_idx] = bottom_hold_active;
     s_ui.xf.pair_fade_down_bottomed[pair->prev_idx] = bottomed;
     return hold_value;
 }
@@ -2226,6 +2275,9 @@ void ui_control_reset_state(void)
         s_ui.xf.fade_up_prev[i]           = 0.0f;
         s_ui.xf.fade_down_prev[i]         = 1.0f;
         s_ui.xf.pair_hold_value[i]         = 0.0f;
+        s_ui.xf.pair_bottom_restore_value[i] = 0.0f;
+        s_ui.xf.pair_fade_down_cut_active[i] = false;
+        s_ui.xf.pair_bottom_hold_active[i] = false;
         s_ui.xf.pair_fade_down_bottomed[i] = false;
     }
     mark_xfade_cut_margin_dirty();

--- a/STM32CubeIDE/JUMBLEQ/Appli/Core/Src/ui_control.c
+++ b/STM32CubeIDE/JUMBLEQ/Appli/Core/Src/ui_control.c
@@ -78,7 +78,7 @@ typedef struct
     float up_peak[MAG_SW_NUM];
     float up_peak_prev[2];
     float down_floor_prev[2];
-    bool pair_gate_on[2];
+    bool pair_gate_open[2];
     bool pair_fade_down_latched[2];
     bool pair_fade_down_bottomed[2];
     bool pair_fade_down_returning[2];
@@ -122,8 +122,8 @@ typedef struct
     uint32_t mag_offset_sum[MAG_SW_NUM];
     uint16_t mag_offset[MAG_SW_NUM];
     xfade_state_t xf;
-    float curve_exp_a;
-    float curve_exp_b;
+    float xfade_cut_margin_a;
+    float xfade_cut_margin_b;
     bool mag_out_as_note;
     bool curve_edit_mode;
     bool is_start_audio_control;
@@ -139,8 +139,8 @@ static ui_control_state_t s_ui = {
     .current_hp_out_source  = CUE_SEL_MST,
     .current_ch1_dvs_enable = 0U,
     .current_ch2_dvs_enable = 0U,
-    .curve_exp_a            = UI_XFADE_CURVE_EXP_A_DEFAULT,
-    .curve_exp_b            = UI_XFADE_CURVE_EXP_B_DEFAULT,
+    .xfade_cut_margin_a     = UI_XFADE_CUT_MARGIN_A_DEFAULT,
+    .xfade_cut_margin_b     = UI_XFADE_CUT_MARGIN_B_DEFAULT,
     .mag_out_as_note        = false,
     .curve_edit_mode        = false,
     .xf.position_a          = 0,
@@ -151,7 +151,7 @@ static ui_control_state_t s_ui = {
     .xf.up_peak             = {0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f},
     .xf.up_peak_prev        = {0.0f, 0.0f},
     .xf.down_floor_prev     = {1.0f, 1.0f},
-    .xf.pair_gate_on             = {false, false},
+    .xf.pair_gate_open           = {false, false},
     .xf.pair_fade_down_latched   = {false, false},
     .xf.pair_fade_down_bottomed  = {false, false},
     .xf.pair_fade_down_returning = {false, false},
@@ -171,13 +171,10 @@ static const float XFADE_MIN_RESET_CUTOFF       = 0.05f;
 static const float XFADE_PAIR_ONSET_DEADBAND    = 0.05f;
 static const float XFADE_PAIR_CUT_MARGIN_MIN    = 0.04f;
 static const float XFADE_PAIR_CUT_MARGIN_MAX    = 0.45f;
-static const float XFADE_PAIR_CUT_MARGIN_SCALE  = 8.0f;
-static const float XFADE_CURVE_EXP_MIN          = 0.5f;
-static const float XFADE_CURVE_EXP_MAX          = 100.0f;
 
 static const uint8_t MIDI_CH_15                  = 14U;  // zero-based MIDI channel index.
-static const uint8_t MIDI_CC_XFADE_CURVE_EXP_A   = 20U;
-static const uint8_t MIDI_CC_XFADE_CURVE_EXP_B   = 21U;
+static const uint8_t MIDI_CC_XFADE_CUT_MARGIN_A  = 20U;
+static const uint8_t MIDI_CC_XFADE_CUT_MARGIN_B  = 21U;
 static const uint8_t MIDI_PC_CURVE_EDIT_MODE_OFF = 120U;
 static const uint8_t MIDI_PC_CURVE_EDIT_MODE_ON  = 121U;
 static const uint8_t MIDI_PC_MUX_OUTPUT_CC       = 122U;
@@ -409,7 +406,7 @@ static uint8_t xfade_to_cc(float xfade)
     return (uint8_t) (127.0f - xfade * 127.0f);
 }
 
-static void mark_xfade_curve_dirty(void)
+static void mark_xfade_cut_margin_dirty(void)
 {
     for (uint8_t i = 0; i < XFADE_PAIR_COUNT; i++)
     {
@@ -418,28 +415,27 @@ static void mark_xfade_curve_dirty(void)
     }
 }
 
-static float midi_cc_to_curve_exp(uint8_t value)
+static float midi_cc_to_xfade_cut_margin(uint8_t value)
 {
-    const float t     = (float) value / 127.0f;
-    const float ratio = XFADE_CURVE_EXP_MAX / XFADE_CURVE_EXP_MIN;
+    const float t = (float) value / 127.0f;
 
-    return XFADE_CURVE_EXP_MIN * powf(ratio, t);
+    return XFADE_PAIR_CUT_MARGIN_MAX + ((XFADE_PAIR_CUT_MARGIN_MIN - XFADE_PAIR_CUT_MARGIN_MAX) * t);
 }
 
-static uint8_t curve_exp_to_midi_cc(float curve_exp)
+static uint8_t xfade_cut_margin_to_midi_cc(float margin)
 {
     float t;
 
-    if (curve_exp < XFADE_CURVE_EXP_MIN)
+    if (margin < XFADE_PAIR_CUT_MARGIN_MIN)
     {
-        curve_exp = XFADE_CURVE_EXP_MIN;
+        margin = XFADE_PAIR_CUT_MARGIN_MIN;
     }
-    else if (curve_exp > XFADE_CURVE_EXP_MAX)
+    else if (margin > XFADE_PAIR_CUT_MARGIN_MAX)
     {
-        curve_exp = XFADE_CURVE_EXP_MAX;
+        margin = XFADE_PAIR_CUT_MARGIN_MAX;
     }
 
-    t = logf(curve_exp / XFADE_CURVE_EXP_MIN) / logf(XFADE_CURVE_EXP_MAX / XFADE_CURVE_EXP_MIN);
+    t = (XFADE_PAIR_CUT_MARGIN_MAX - margin) / (XFADE_PAIR_CUT_MARGIN_MAX - XFADE_PAIR_CUT_MARGIN_MIN);
     if (t < 0.0f)
     {
         t = 0.0f;
@@ -452,15 +448,15 @@ static uint8_t curve_exp_to_midi_cc(float curve_exp)
     return (uint8_t) ((t * 127.0f) + 0.5f);
 }
 
-static float clamp_curve_exp(float value)
+static float clamp_xfade_cut_margin(float value)
 {
-    if (value < XFADE_CURVE_EXP_MIN)
+    if (value < XFADE_PAIR_CUT_MARGIN_MIN)
     {
-        return XFADE_CURVE_EXP_MIN;
+        return XFADE_PAIR_CUT_MARGIN_MIN;
     }
-    if (value > XFADE_CURVE_EXP_MAX)
+    if (value > XFADE_PAIR_CUT_MARGIN_MAX)
     {
-        return XFADE_CURVE_EXP_MAX;
+        return XFADE_PAIR_CUT_MARGIN_MAX;
     }
     return value;
 }
@@ -714,24 +710,24 @@ bool ui_control_is_curve_edit_mode_enabled(void)
     return s_ui.curve_edit_mode;
 }
 
-float ui_control_get_curve_exp_a(void)
+float ui_control_get_xfade_cut_margin_a(void)
 {
-    return s_ui.curve_exp_a;
+    return s_ui.xfade_cut_margin_a;
 }
 
-float ui_control_get_curve_exp_b(void)
+float ui_control_get_xfade_cut_margin_b(void)
 {
-    return s_ui.curve_exp_b;
+    return s_ui.xfade_cut_margin_b;
 }
 
-uint8_t ui_control_get_curve_exp_a_cc(void)
+uint8_t ui_control_get_xfade_cut_margin_a_cc(void)
 {
-    return curve_exp_to_midi_cc(s_ui.curve_exp_a);
+    return xfade_cut_margin_to_midi_cc(s_ui.xfade_cut_margin_a);
 }
 
-uint8_t ui_control_get_curve_exp_b_cc(void)
+uint8_t ui_control_get_xfade_cut_margin_b_cc(void)
 {
-    return curve_exp_to_midi_cc(s_ui.curve_exp_b);
+    return xfade_cut_margin_to_midi_cc(s_ui.xfade_cut_margin_b);
 }
 
 void ui_control_dma_adc_cplt(DMA_HandleTypeDef* hdma)
@@ -1110,8 +1106,8 @@ static void send_midi_config_dump(const EEPROM_DeviceConfig_t* cfg)
     send_program_change(midi_program_for_hp_out_source(cfg->current_hp_out_source), MIDI_CH_15);
     send_program_change(midi_program_for_dvs(INPUT_CH1, cfg->current_ch1_dvs_enable), MIDI_CH_15);
     send_program_change(midi_program_for_dvs(INPUT_CH2, cfg->current_ch2_dvs_enable), MIDI_CH_15);
-    send_control_change(MIDI_CC_XFADE_CURVE_EXP_A, curve_exp_to_midi_cc(cfg->current_xf_curve_exp_a), MIDI_CH_15);
-    send_control_change(MIDI_CC_XFADE_CURVE_EXP_B, curve_exp_to_midi_cc(cfg->current_xf_curve_exp_b), MIDI_CH_15);
+    send_control_change(MIDI_CC_XFADE_CUT_MARGIN_A, xfade_cut_margin_to_midi_cc(cfg->current_xfade_cut_margin_a), MIDI_CH_15);
+    send_control_change(MIDI_CC_XFADE_CUT_MARGIN_B, xfade_cut_margin_to_midi_cc(cfg->current_xfade_cut_margin_b), MIDI_CH_15);
     if ((cfg->mag_output_mode_flags & EEPROM_CFG_FLAG_MAG_OUT_AS_NOTE) != 0U)
     {
         send_program_change(MIDI_PC_MUX_OUTPUT_NOTE, MIDI_CH_15);
@@ -1509,7 +1505,7 @@ static int8_t get_pair_fade_up_index_from_down(uint8_t fade_down_idx)
 }
 
 // Add a small touch-onset deadband for pair tracking so untouched sensors do not
-// perturb the held crossfader state when curve_exp is large.
+// perturb the held crossfader state when the cut margin is narrow.
 static float apply_xfade_pair_onset_deadband(uint8_t i, float raw)
 {
     if (raw < 0.0f)
@@ -1696,20 +1692,19 @@ static float clamp01(float value)
     return value;
 }
 
-static float compute_xfade_pair_cut_margin(float curve_exp)
+static float compute_xfade_pair_transition_width(float margin)
 {
-    float margin = XFADE_PAIR_CUT_MARGIN_SCALE / curve_exp;
+    return margin * 0.5f;
+}
 
-    if (margin < XFADE_PAIR_CUT_MARGIN_MIN)
+static float compute_xfade_pair_threshold_ramp(float value, float threshold, float width)
+{
+    if (width <= 0.0f)
     {
-        return XFADE_PAIR_CUT_MARGIN_MIN;
-    }
-    if (margin > XFADE_PAIR_CUT_MARGIN_MAX)
-    {
-        return XFADE_PAIR_CUT_MARGIN_MAX;
+        return (value >= threshold) ? 1.0f : 0.0f;
     }
 
-    return margin;
+    return clamp01((value - threshold) / width);
 }
 
 static float get_xfade_pair_fade_down_raw(const xfade_pair_runtime_t* pair)
@@ -1719,10 +1714,11 @@ static float get_xfade_pair_fade_down_raw(const xfade_pair_runtime_t* pair)
 
 static float compute_xfade_pair_value(const xfade_pair_runtime_t* pair)
 {
-    const float curve_exp = (pair->prev_idx == XFADE_PAIR_A) ? s_ui.curve_exp_a : s_ui.curve_exp_b;
-    const float base      = clamp01(s_ui.xf.up_peak[pair->fade_up_idx] * s_ui.xf.down_floor[pair->fade_down_idx]);
-    const float margin    = compute_xfade_pair_cut_margin(curve_exp);
+    const float xfade_cut_margin = (pair->prev_idx == XFADE_PAIR_A) ? s_ui.xfade_cut_margin_a : s_ui.xfade_cut_margin_b;
+    const float base             = clamp01(s_ui.xf.up_peak[pair->fade_up_idx] * s_ui.xf.down_floor[pair->fade_down_idx]);
+    const float margin           = clamp_xfade_cut_margin(xfade_cut_margin);
     const float fade_down = get_xfade_pair_fade_down_raw(pair);
+    const float transition_width             = compute_xfade_pair_transition_width(margin);
     // fade-down starts cutting once the sensor moves this far from its unpressed (1.0) position.
     const float down_press_threshold           = 1.0f - margin;
     // Normal release path: require the fade-down side to return close to unpressed before reopening.
@@ -1731,12 +1727,13 @@ static float compute_xfade_pair_value(const xfade_pair_runtime_t* pair)
     const float down_bottom_threshold       = margin * 0.5f;
     // After bottoming out, allow reopening much earlier so a small lift can bring audio back.
     const float down_bottom_release_threshold = margin;
-    bool gate_on                            = s_ui.xf.pair_gate_on[pair->prev_idx];
+    bool gate_open                          = s_ui.xf.pair_gate_open[pair->prev_idx];
     bool fade_down_latched                  = s_ui.xf.pair_fade_down_latched[pair->prev_idx];
     // Remembers whether this fade-down gesture reached the bottom zone.
     bool fade_down_bottomed                 = s_ui.xf.pair_fade_down_bottomed[pair->prev_idx];
     // Masks the normal fade-down press threshold while the sensor is returning after a bottomed reopen.
     bool fade_down_returning                = s_ui.xf.pair_fade_down_returning[pair->prev_idx];
+    float output                            = 0.0f;
 
     if (!fade_down_latched && !fade_down_returning && fade_down <= down_press_threshold)
     {
@@ -1776,18 +1773,30 @@ static float compute_xfade_pair_value(const xfade_pair_runtime_t* pair)
 
     if (fade_down_latched)
     {
-        gate_on = false;
+        gate_open = false;
     }
     else
     {
-        gate_on = (base >= margin);
+        gate_open = (base >= margin);
+
+        if (gate_open)
+        {
+            if (fade_down_returning)
+            {
+                output = compute_xfade_pair_threshold_ramp(fade_down, down_bottom_release_threshold, transition_width);
+            }
+            else
+            {
+                output = compute_xfade_pair_threshold_ramp(fade_down, down_press_threshold, transition_width);
+            }
+        }
     }
 
-    s_ui.xf.pair_gate_on[pair->prev_idx]             = gate_on;
+    s_ui.xf.pair_gate_open[pair->prev_idx]           = gate_open;
     s_ui.xf.pair_fade_down_latched[pair->prev_idx]   = fade_down_latched;
     s_ui.xf.pair_fade_down_bottomed[pair->prev_idx]  = fade_down_bottomed;
     s_ui.xf.pair_fade_down_returning[pair->prev_idx] = fade_down_returning;
-    return gate_on ? 1.0f : 0.0f;
+    return output;
 }
 
 // Compute and commit one pair output (A or B) from tracked extrema.
@@ -1957,7 +1966,7 @@ static bool dispatch_midi_program_change(uint8_t channel, uint8_t program)
 
         EEPROM_ConfigCaptureCurrent(&cfg);
         send_midi_config_dump(&cfg);
-        SEGGER_RTT_printf(0, "Current config dumped by MIDI PC126: CH1=%u CH2=%u XFA=%u XFB=%u XFP=%u RTN=%u HP=%u DVS1=%u DVS2=%u MAG_AS_NOTE=%u CURVE_A=%.4f CURVE_B=%.4f\r\n", (unsigned) cfg.current_ch1_input_type, (unsigned) cfg.current_ch2_input_type, (unsigned) cfg.current_xfA_assign, (unsigned) cfg.current_xfB_assign, (unsigned) cfg.current_xfpost_assign, (unsigned) cfg.current_return_assign, (unsigned) cfg.current_hp_out_source, (unsigned) cfg.current_ch1_dvs_enable, (unsigned) cfg.current_ch2_dvs_enable, (unsigned) ((cfg.mag_output_mode_flags & EEPROM_CFG_FLAG_MAG_OUT_AS_NOTE) != 0U), (double) cfg.current_xf_curve_exp_a, (double) cfg.current_xf_curve_exp_b);
+        SEGGER_RTT_printf(0, "Current config dumped by MIDI PC126: CH1=%u CH2=%u XFA=%u XFB=%u XFP=%u RTN=%u HP=%u DVS1=%u DVS2=%u MAG_AS_NOTE=%u CUT_MARGIN_A=%.4f CUT_MARGIN_B=%.4f\r\n", (unsigned) cfg.current_ch1_input_type, (unsigned) cfg.current_ch2_input_type, (unsigned) cfg.current_xfA_assign, (unsigned) cfg.current_xfB_assign, (unsigned) cfg.current_xfpost_assign, (unsigned) cfg.current_return_assign, (unsigned) cfg.current_hp_out_source, (unsigned) cfg.current_ch1_dvs_enable, (unsigned) cfg.current_ch2_dvs_enable, (unsigned) ((cfg.mag_output_mode_flags & EEPROM_CFG_FLAG_MAG_OUT_AS_NOTE) != 0U), (double) cfg.current_xfade_cut_margin_a, (double) cfg.current_xfade_cut_margin_b);
 
         return true;
     }
@@ -1970,7 +1979,7 @@ static bool dispatch_midi_program_change(uint8_t channel, uint8_t program)
         if (EEPROM_SaveConfig(&hi2c2, &cfg) == HAL_OK)
         {
             led_notify_save_success();
-            SEGGER_RTT_printf(0, "EEPROM config saved by MIDI PC127: CH1=%u CH2=%u XFA=%u XFB=%u XFP=%u RTN=%u HP=%u DVS1=%u DVS2=%u CURVE_A=%.4f CURVE_B=%.4f\r\n", (unsigned) cfg.current_ch1_input_type, (unsigned) cfg.current_ch2_input_type, (unsigned) cfg.current_xfA_assign, (unsigned) cfg.current_xfB_assign, (unsigned) cfg.current_xfpost_assign, (unsigned) cfg.current_return_assign, (unsigned) cfg.current_hp_out_source, (unsigned) cfg.current_ch1_dvs_enable, (unsigned) cfg.current_ch2_dvs_enable, (double) cfg.current_xf_curve_exp_a, (double) cfg.current_xf_curve_exp_b);
+            SEGGER_RTT_printf(0, "EEPROM config saved by MIDI PC127: CH1=%u CH2=%u XFA=%u XFB=%u XFP=%u RTN=%u HP=%u DVS1=%u DVS2=%u CUT_MARGIN_A=%.4f CUT_MARGIN_B=%.4f\r\n", (unsigned) cfg.current_ch1_input_type, (unsigned) cfg.current_ch2_input_type, (unsigned) cfg.current_xfA_assign, (unsigned) cfg.current_xfB_assign, (unsigned) cfg.current_xfpost_assign, (unsigned) cfg.current_return_assign, (unsigned) cfg.current_hp_out_source, (unsigned) cfg.current_ch1_dvs_enable, (unsigned) cfg.current_ch2_dvs_enable, (double) cfg.current_xfade_cut_margin_a, (double) cfg.current_xfade_cut_margin_b);
         }
         else
         {
@@ -2021,7 +2030,7 @@ static bool dispatch_midi_program_change(uint8_t channel, uint8_t program)
 
 static bool dispatch_midi_control_change(uint8_t channel, uint8_t number, uint8_t value)
 {
-    float new_curve_exp;
+    float new_xfade_cut_margin;
 
     if (!s_ui.curve_edit_mode)
     {
@@ -2033,26 +2042,26 @@ static bool dispatch_midi_control_change(uint8_t channel, uint8_t number, uint8_
         return false;
     }
 
-    if (number == MIDI_CC_XFADE_CURVE_EXP_A)
+    if (number == MIDI_CC_XFADE_CUT_MARGIN_A)
     {
-        new_curve_exp = midi_cc_to_curve_exp(value);
-        if (fabsf(new_curve_exp - s_ui.curve_exp_a) > 0.0001f)
+        new_xfade_cut_margin = clamp_xfade_cut_margin(midi_cc_to_xfade_cut_margin(value));
+        if (fabsf(new_xfade_cut_margin - s_ui.xfade_cut_margin_a) > 0.0001f)
         {
-            s_ui.curve_exp_a = new_curve_exp;
-            mark_xfade_curve_dirty();
-            SEGGER_RTT_printf(0, "Curve A updated by CC%u Ch15 -> %.4f\r\n", (unsigned) number, (double) s_ui.curve_exp_a);
+            s_ui.xfade_cut_margin_a = new_xfade_cut_margin;
+            mark_xfade_cut_margin_dirty();
+            SEGGER_RTT_printf(0, "Cut margin A updated by CC%u Ch15 -> %.4f\r\n", (unsigned) number, (double) s_ui.xfade_cut_margin_a);
         }
         return true;
     }
 
-    if (number == MIDI_CC_XFADE_CURVE_EXP_B)
+    if (number == MIDI_CC_XFADE_CUT_MARGIN_B)
     {
-        new_curve_exp = midi_cc_to_curve_exp(value);
-        if (fabsf(new_curve_exp - s_ui.curve_exp_b) > 0.0001f)
+        new_xfade_cut_margin = clamp_xfade_cut_margin(midi_cc_to_xfade_cut_margin(value));
+        if (fabsf(new_xfade_cut_margin - s_ui.xfade_cut_margin_b) > 0.0001f)
         {
-            s_ui.curve_exp_b = new_curve_exp;
-            mark_xfade_curve_dirty();
-            SEGGER_RTT_printf(0, "Curve B updated by CC%u Ch15 -> %.4f\r\n", (unsigned) number, (double) s_ui.curve_exp_b);
+            s_ui.xfade_cut_margin_b = new_xfade_cut_margin;
+            mark_xfade_cut_margin_dirty();
+            SEGGER_RTT_printf(0, "Cut margin B updated by CC%u Ch15 -> %.4f\r\n", (unsigned) number, (double) s_ui.xfade_cut_margin_b);
         }
         return true;
     }
@@ -2125,11 +2134,11 @@ void ui_control_get_persist_state(UI_ControlPersistState_t* state)
     state->current_xfpost_assign  = s_ui.current_xfpost_assign;
     state->current_return_assign  = s_ui.current_return_assign;
     state->current_hp_out_source  = s_ui.current_hp_out_source;
-    state->current_ch1_dvs_enable = s_ui.current_ch1_dvs_enable;
-    state->current_ch2_dvs_enable = s_ui.current_ch2_dvs_enable;
-    state->current_xf_curve_exp_a = s_ui.curve_exp_a;
-    state->current_xf_curve_exp_b = s_ui.curve_exp_b;
-    state->mag_out_as_note        = s_ui.mag_out_as_note;
+    state->current_ch1_dvs_enable    = s_ui.current_ch1_dvs_enable;
+    state->current_ch2_dvs_enable    = s_ui.current_ch2_dvs_enable;
+    state->current_xfade_cut_margin_a = s_ui.xfade_cut_margin_a;
+    state->current_xfade_cut_margin_b = s_ui.xfade_cut_margin_b;
+    state->mag_out_as_note           = s_ui.mag_out_as_note;
 }
 
 bool ui_control_apply_persist_state(const UI_ControlPersistState_t* state)
@@ -2170,10 +2179,10 @@ bool ui_control_apply_persist_state(const UI_ControlPersistState_t* state)
     apply_hp_out_source(state->current_hp_out_source);
     apply_dvs_state(INPUT_CH1, state->current_ch1_dvs_enable != 0U);
     apply_dvs_state(INPUT_CH2, state->current_ch2_dvs_enable != 0U);
-    s_ui.curve_exp_a     = clamp_curve_exp(state->current_xf_curve_exp_a);
-    s_ui.curve_exp_b     = clamp_curve_exp(state->current_xf_curve_exp_b);
-    s_ui.mag_out_as_note = state->mag_out_as_note;
-    mark_xfade_curve_dirty();
+    s_ui.xfade_cut_margin_a = clamp_xfade_cut_margin(state->current_xfade_cut_margin_a);
+    s_ui.xfade_cut_margin_b = clamp_xfade_cut_margin(state->current_xfade_cut_margin_b);
+    s_ui.mag_out_as_note    = state->mag_out_as_note;
+    mark_xfade_cut_margin_dirty();
 
     return true;
 }
@@ -2233,8 +2242,8 @@ void ui_control_reset_state(void)
     s_ui.current_hp_out_source  = CUE_SEL_MST;
     s_ui.current_ch1_dvs_enable = 0U;
     s_ui.current_ch2_dvs_enable = 0U;
-    s_ui.curve_exp_a            = UI_XFADE_CURVE_EXP_A_DEFAULT;
-    s_ui.curve_exp_b            = UI_XFADE_CURVE_EXP_B_DEFAULT;
+    s_ui.xfade_cut_margin_a     = UI_XFADE_CUT_MARGIN_A_DEFAULT;
+    s_ui.xfade_cut_margin_b     = UI_XFADE_CUT_MARGIN_B_DEFAULT;
     s_ui.curve_edit_mode        = false;
     s_ui.xf.position_a          = 0;
     s_ui.xf.position_b          = 0;
@@ -2254,12 +2263,12 @@ void ui_control_reset_state(void)
     {
         s_ui.xf.up_peak_prev[i]             = 0.0f;
         s_ui.xf.down_floor_prev[i]          = 1.0f;
-        s_ui.xf.pair_gate_on[i]             = false;
+        s_ui.xf.pair_gate_open[i]           = false;
         s_ui.xf.pair_fade_down_latched[i]   = false;
         s_ui.xf.pair_fade_down_bottomed[i]  = false;
         s_ui.xf.pair_fade_down_returning[i] = false;
     }
-    mark_xfade_curve_dirty();
+    mark_xfade_cut_margin_dirty();
     s_ui.xf.extrema_prev_valid = false;
 
     for (uint16_t i = 0; i < 128U; i++)

--- a/STM32CubeIDE/JUMBLEQ/Appli/Core/Src/ui_control.c
+++ b/STM32CubeIDE/JUMBLEQ/Appli/Core/Src/ui_control.c
@@ -78,6 +78,10 @@ typedef struct
     float up_peak[MAG_SW_NUM];
     float up_peak_prev[2];
     float down_floor_prev[2];
+    bool pair_gate_on[2];
+    bool pair_fade_down_latched[2];
+    bool pair_fade_down_bottomed[2];
+    bool pair_fade_down_returning[2];
     bool extrema_prev_valid;
     uint8_t note_peak_vel[MAG_SW_NUM];
     uint32_t note_scan_start_ms[MAG_SW_NUM];
@@ -147,6 +151,10 @@ static ui_control_state_t s_ui = {
     .xf.up_peak             = {0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f},
     .xf.up_peak_prev        = {0.0f, 0.0f},
     .xf.down_floor_prev     = {1.0f, 1.0f},
+    .xf.pair_gate_on             = {false, false},
+    .xf.pair_fade_down_latched   = {false, false},
+    .xf.pair_fade_down_bottomed  = {false, false},
+    .xf.pair_fade_down_returning = {false, false},
     .xf.extrema_prev_valid  = false,
     .is_start_audio_control = false,
 };
@@ -161,6 +169,9 @@ static const float XFADE_EXTREMA_SEND_THRESHOLD = 0.002f;
 static const float XFADE_PAIR_RESET_THRESHOLD   = 0.98f;
 static const float XFADE_MIN_RESET_CUTOFF       = 0.05f;
 static const float XFADE_PAIR_ONSET_DEADBAND    = 0.05f;
+static const float XFADE_PAIR_CUT_MARGIN_MIN    = 0.04f;
+static const float XFADE_PAIR_CUT_MARGIN_MAX    = 0.45f;
+static const float XFADE_PAIR_CUT_MARGIN_SCALE  = 8.0f;
 static const float XFADE_CURVE_EXP_MIN          = 0.5f;
 static const float XFADE_CURVE_EXP_MAX          = 100.0f;
 
@@ -1671,21 +1682,112 @@ static void emit_xfade_cc_if_needed(uint8_t i)
     }
 }
 
+static float clamp01(float value)
+{
+    if (value < 0.0f)
+    {
+        return 0.0f;
+    }
+    if (value > 1.0f)
+    {
+        return 1.0f;
+    }
+
+    return value;
+}
+
+static float compute_xfade_pair_cut_margin(float curve_exp)
+{
+    float margin = XFADE_PAIR_CUT_MARGIN_SCALE / curve_exp;
+
+    if (margin < XFADE_PAIR_CUT_MARGIN_MIN)
+    {
+        return XFADE_PAIR_CUT_MARGIN_MIN;
+    }
+    if (margin > XFADE_PAIR_CUT_MARGIN_MAX)
+    {
+        return XFADE_PAIR_CUT_MARGIN_MAX;
+    }
+
+    return margin;
+}
+
+static float get_xfade_pair_fade_down_raw(const xfade_pair_runtime_t* pair)
+{
+    return apply_xfade_pair_onset_deadband(pair->fade_down_idx, s_ui.xf.raw[pair->fade_down_idx]);
+}
+
 static float compute_xfade_pair_value(const xfade_pair_runtime_t* pair)
 {
     const float curve_exp = (pair->prev_idx == XFADE_PAIR_A) ? s_ui.curve_exp_a : s_ui.curve_exp_b;
-    float base            = s_ui.xf.up_peak[pair->fade_up_idx] * s_ui.xf.down_floor[pair->fade_down_idx];
+    const float base      = clamp01(s_ui.xf.up_peak[pair->fade_up_idx] * s_ui.xf.down_floor[pair->fade_down_idx]);
+    const float margin    = compute_xfade_pair_cut_margin(curve_exp);
+    const float fade_down = get_xfade_pair_fade_down_raw(pair);
+    // fade-down starts cutting once the sensor moves this far from its unpressed (1.0) position.
+    const float down_press_threshold           = 1.0f - margin;
+    // Normal release path: require the fade-down side to return close to unpressed before reopening.
+    const float down_partial_release_threshold = 1.0f - (margin * 0.5f);
+    // "Deep" means the fade-down side reached near-bottom during the current gesture.
+    const float down_bottom_threshold       = margin * 0.5f;
+    // After bottoming out, allow reopening much earlier so a small lift can bring audio back.
+    const float down_bottom_release_threshold = margin;
+    bool gate_on                            = s_ui.xf.pair_gate_on[pair->prev_idx];
+    bool fade_down_latched                  = s_ui.xf.pair_fade_down_latched[pair->prev_idx];
+    // Remembers whether this fade-down gesture reached the bottom zone.
+    bool fade_down_bottomed                 = s_ui.xf.pair_fade_down_bottomed[pair->prev_idx];
+    // Masks the normal fade-down press threshold while the sensor is returning after a bottomed reopen.
+    bool fade_down_returning                = s_ui.xf.pair_fade_down_returning[pair->prev_idx];
 
-    if (base < 0.0f)
+    if (!fade_down_latched && !fade_down_returning && fade_down <= down_press_threshold)
     {
-        base = 0.0f;
+        fade_down_latched  = true;
+        fade_down_bottomed = (fade_down <= down_bottom_threshold);
     }
-    else if (base > 1.0f)
+    else if (fade_down_latched)
     {
-        base = 1.0f;
+        if (fade_down <= down_bottom_threshold)
+        {
+            fade_down_bottomed = true;
+        }
+
+        // Release the fade-down latch when the sensor has returned far enough:
+        // use the earlier bottomed-release point after a bottom-out press, otherwise
+        // wait until the normal partial-release point near unpressed.
+        if (fade_down >= (fade_down_bottomed ? down_bottom_release_threshold : down_partial_release_threshold))
+        {
+            fade_down_latched   = false;
+            fade_down_returning = fade_down_bottomed;
+            fade_down_bottomed  = false;
+        }
+    }
+    else if (fade_down_returning)
+    {
+        if (fade_down >= down_partial_release_threshold)
+        {
+            fade_down_returning = false;
+        }
+        else if (fade_down <= down_bottom_threshold)
+        {
+            fade_down_latched   = true;
+            fade_down_bottomed  = true;
+            fade_down_returning = false;
+        }
     }
 
-    return powf(base, curve_exp);
+    if (fade_down_latched)
+    {
+        gate_on = false;
+    }
+    else
+    {
+        gate_on = (base >= margin);
+    }
+
+    s_ui.xf.pair_gate_on[pair->prev_idx]             = gate_on;
+    s_ui.xf.pair_fade_down_latched[pair->prev_idx]   = fade_down_latched;
+    s_ui.xf.pair_fade_down_bottomed[pair->prev_idx]  = fade_down_bottomed;
+    s_ui.xf.pair_fade_down_returning[pair->prev_idx] = fade_down_returning;
+    return gate_on ? 1.0f : 0.0f;
 }
 
 // Compute and commit one pair output (A or B) from tracked extrema.
@@ -2150,8 +2252,12 @@ void ui_control_reset_state(void)
     }
     for (uint8_t i = 0; i < XFADE_PAIR_COUNT; i++)
     {
-        s_ui.xf.up_peak_prev[i]    = 0.0f;
-        s_ui.xf.down_floor_prev[i] = 1.0f;
+        s_ui.xf.up_peak_prev[i]             = 0.0f;
+        s_ui.xf.down_floor_prev[i]          = 1.0f;
+        s_ui.xf.pair_gate_on[i]             = false;
+        s_ui.xf.pair_fade_down_latched[i]   = false;
+        s_ui.xf.pair_fade_down_bottomed[i]  = false;
+        s_ui.xf.pair_fade_down_returning[i] = false;
     }
     mark_xfade_curve_dirty();
     s_ui.xf.extrema_prev_valid = false;

--- a/STM32CubeIDE/JUMBLEQ/Appli/Core/Src/ui_control.c
+++ b/STM32CubeIDE/JUMBLEQ/Appli/Core/Src/ui_control.c
@@ -1715,10 +1715,12 @@ static float get_xfade_pair_fade_down_raw(const xfade_pair_runtime_t* pair)
 static float compute_xfade_pair_value(const xfade_pair_runtime_t* pair)
 {
     const float xfade_cut_margin = (pair->prev_idx == XFADE_PAIR_A) ? s_ui.xfade_cut_margin_a : s_ui.xfade_cut_margin_b;
-    const float base             = clamp01(s_ui.xf.up_peak[pair->fade_up_idx] * s_ui.xf.down_floor[pair->fade_down_idx]);
+    const float fade_up          = s_ui.xf.up_peak[pair->fade_up_idx];
     const float margin           = clamp_xfade_cut_margin(xfade_cut_margin);
-    const float fade_down = get_xfade_pair_fade_down_raw(pair);
-    const float transition_width             = compute_xfade_pair_transition_width(margin);
+    const float fade_down        = get_xfade_pair_fade_down_raw(pair);
+    const float transition_width = compute_xfade_pair_transition_width(margin);
+    // fade-up starts opening once the paired sensor rises past the cut margin.
+    const float up_open_threshold             = margin;
     // fade-down starts cutting once the sensor moves this far from its unpressed (1.0) position.
     const float down_press_threshold           = 1.0f - margin;
     // Normal release path: require the fade-down side to return close to unpressed before reopening.
@@ -1733,6 +1735,8 @@ static float compute_xfade_pair_value(const xfade_pair_runtime_t* pair)
     bool fade_down_bottomed                 = s_ui.xf.pair_fade_down_bottomed[pair->prev_idx];
     // Masks the normal fade-down press threshold while the sensor is returning after a bottomed reopen.
     bool fade_down_returning                = s_ui.xf.pair_fade_down_returning[pair->prev_idx];
+    float up_gain                           = compute_xfade_pair_threshold_ramp(fade_up, up_open_threshold, transition_width);
+    float down_gain                         = 0.0f;
     float output                            = 0.0f;
 
     if (!fade_down_latched && !fade_down_returning && fade_down <= down_press_threshold)
@@ -1773,24 +1777,19 @@ static float compute_xfade_pair_value(const xfade_pair_runtime_t* pair)
 
     if (fade_down_latched)
     {
-        gate_open = false;
+        down_gain = 0.0f;
+    }
+    else if (fade_down_returning)
+    {
+        down_gain = compute_xfade_pair_threshold_ramp(fade_down, down_bottom_release_threshold, transition_width);
     }
     else
     {
-        gate_open = (base >= margin);
-
-        if (gate_open)
-        {
-            if (fade_down_returning)
-            {
-                output = compute_xfade_pair_threshold_ramp(fade_down, down_bottom_release_threshold, transition_width);
-            }
-            else
-            {
-                output = compute_xfade_pair_threshold_ramp(fade_down, down_press_threshold, transition_width);
-            }
-        }
+        down_gain = compute_xfade_pair_threshold_ramp(fade_down, down_press_threshold, transition_width);
     }
+
+    output    = up_gain * down_gain;
+    gate_open = (output > 0.0f);
 
     s_ui.xf.pair_gate_open[pair->prev_idx]           = gate_open;
     s_ui.xf.pair_fade_down_latched[pair->prev_idx]   = fade_down_latched;

--- a/STM32CubeIDE/JUMBLEQ/Appli/Core/Src/ui_control.c
+++ b/STM32CubeIDE/JUMBLEQ/Appli/Core/Src/ui_control.c
@@ -70,23 +70,28 @@ __attribute__((section("noncacheable_buffer"), aligned(32))) uint32_t adc_val[AD
 // State used by magnetic-switch crossfader processing.
 typedef struct
 {
-    uint8_t position_a;
-    uint8_t position_b;
-    float raw[MAG_SW_NUM];
-    float prev[MAG_SW_NUM];
-    float down_floor[MAG_SW_NUM];
-    float up_peak[MAG_SW_NUM];
-    float up_peak_prev[2];
-    float down_floor_prev[2];
-    bool pair_gate_open[2];
-    bool pair_fade_down_latched[2];
-    bool pair_fade_down_bottomed[2];
-    bool pair_fade_down_returning[2];
-    bool extrema_prev_valid;
-    uint8_t note_peak_vel[MAG_SW_NUM];
-    uint32_t note_scan_start_ms[MAG_SW_NUM];
-    bool note_is_on[MAG_SW_NUM];
-    bool note_scan_active[MAG_SW_NUM];
+    uint8_t position_a;  // Last quantized output value sent to xfade pair A.
+    uint8_t position_b;  // Last quantized output value sent to xfade pair B.
+    float raw[MAG_SW_NUM];  // Per-sensor normalized raw value after magnetic conversion.
+    float prev[MAG_SW_NUM];  // Previous raw value used for outgoing MIDI CC change detection.
+    float down_floor[MAG_SW_NUM];  // Per-sensor held minimum used by paired fade-down tracking.
+    float up_peak[MAG_SW_NUM];  // Per-sensor held maximum used by paired fade-up tracking.
+    float pair_hold_value[2];  // Current held output value for each xfade pair.
+    float up_peak_prev[2];  // Previous fade-up drive value used to detect when pair output needs recomputing.
+    float down_floor_prev[2];  // Previous fade-down drive value used to detect when pair output needs recomputing.
+    float pair_fade_down_hold_floor[2];  // Legacy pair scratch value; cleared in the current hold-value model.
+    float pair_fade_up_hold_start[2];  // Legacy pair scratch value; cleared in the current hold-value model.
+    bool pair_fade_up_hold_rearmed[2];  // Legacy pair scratch flag; cleared in the current hold-value model.
+    bool pair_gate_open[2];  // Latest computed nonzero-output flag for each xfade pair.
+    bool pair_fade_down_held[2];  // Legacy pair scratch flag; kept reset in the current hold-value model.
+    bool pair_fade_down_latched[2];  // Legacy pair scratch flag; kept reset in the current hold-value model.
+    bool pair_fade_down_bottomed[2];  // Whether each pair is currently in the fade-down bottom zone.
+    bool pair_fade_down_returning[2];  // Legacy pair scratch flag; kept reset in the current hold-value model.
+    bool extrema_prev_valid;  // Whether the previous pair-drive snapshots have been initialized.
+    uint8_t note_peak_vel[MAG_SW_NUM];  // Peak velocity captured while scanning one xfade sensor note-on edge.
+    uint32_t note_scan_start_ms[MAG_SW_NUM];  // Start tick for one xfade sensor note velocity scan window.
+    bool note_is_on[MAG_SW_NUM];  // Whether each xfade sensor note output is currently on.
+    bool note_scan_active[MAG_SW_NUM];  // Whether each xfade sensor is accumulating note-on velocity.
 } xfade_state_t;
 
 // Aggregated UI runtime state (ADC-derived controls + persisted selections).
@@ -149,9 +154,14 @@ static ui_control_state_t s_ui = {
     .xf.prev                = {1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f},
     .xf.down_floor          = {1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f},
     .xf.up_peak             = {0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f},
+    .xf.pair_hold_value     = {0.0f, 0.0f},
     .xf.up_peak_prev        = {0.0f, 0.0f},
     .xf.down_floor_prev     = {1.0f, 1.0f},
+    .xf.pair_fade_down_hold_floor = {1.0f, 1.0f},
+    .xf.pair_fade_up_hold_start   = {0.0f, 0.0f},
+    .xf.pair_fade_up_hold_rearmed = {false, false},
     .xf.pair_gate_open           = {false, false},
+    .xf.pair_fade_down_held      = {false, false},
     .xf.pair_fade_down_latched   = {false, false},
     .xf.pair_fade_down_bottomed  = {false, false},
     .xf.pair_fade_down_returning = {false, false},
@@ -171,6 +181,7 @@ static const float XFADE_MIN_RESET_CUTOFF       = 0.05f;
 static const float XFADE_PAIR_ONSET_DEADBAND    = 0.05f;
 static const float XFADE_PAIR_CUT_MARGIN_MIN    = 0.04f;
 static const float XFADE_PAIR_CUT_MARGIN_MAX    = 0.45f;
+static const float XFADE_PAIR_RAMP_LINEAR_BLEND = 0.60f;
 
 static const uint8_t MIDI_CH_15                  = 14U;  // zero-based MIDI channel index.
 static const uint8_t MIDI_CC_XFADE_CUT_MARGIN_A  = 20U;
@@ -1694,17 +1705,22 @@ static float clamp01(float value)
 
 static float compute_xfade_pair_transition_width(float margin)
 {
-    return margin * 0.5f;
+    return margin;
 }
 
 static float compute_xfade_pair_threshold_ramp(float value, float threshold, float width)
 {
+    float t;
+    float smootherstep;
+
     if (width <= 0.0f)
     {
         return (value >= threshold) ? 1.0f : 0.0f;
     }
 
-    return clamp01((value - threshold) / width);
+    t = clamp01((value - threshold) / width);
+    smootherstep = t * t * t * (t * ((t * 6.0f) - 15.0f) + 10.0f);
+    return (XFADE_PAIR_RAMP_LINEAR_BLEND * t) + ((1.0f - XFADE_PAIR_RAMP_LINEAR_BLEND) * smootherstep);
 }
 
 static float get_xfade_pair_fade_down_raw(const xfade_pair_runtime_t* pair)
@@ -1712,101 +1728,78 @@ static float get_xfade_pair_fade_down_raw(const xfade_pair_runtime_t* pair)
     return apply_xfade_pair_onset_deadband(pair->fade_down_idx, s_ui.xf.raw[pair->fade_down_idx]);
 }
 
+static float get_xfade_pair_fade_up_raw(const xfade_pair_runtime_t* pair)
+{
+    return apply_xfade_pair_onset_deadband(pair->fade_up_idx, s_ui.xf.raw[pair->fade_up_idx]);
+}
+
 static float compute_xfade_pair_value(const xfade_pair_runtime_t* pair)
 {
     const float xfade_cut_margin = (pair->prev_idx == XFADE_PAIR_A) ? s_ui.xfade_cut_margin_a : s_ui.xfade_cut_margin_b;
-    const float fade_up          = s_ui.xf.up_peak[pair->fade_up_idx];
+    const float fade_up_raw      = get_xfade_pair_fade_up_raw(pair);
     const float margin           = clamp_xfade_cut_margin(xfade_cut_margin);
     const float fade_down        = get_xfade_pair_fade_down_raw(pair);
     const float transition_width = compute_xfade_pair_transition_width(margin);
-    // fade-up starts opening once the paired sensor rises past the cut margin.
-    const float up_open_threshold             = margin;
+    // fade-up opens across the first margin-wide slice of travel after onset deadband.
+    const float up_open_threshold             = 0.0f;
+    const float up_transition_width           = margin;
     // fade-down starts cutting once the sensor moves this far from its unpressed (1.0) position.
     const float down_press_threshold           = 1.0f - margin;
-    // Normal release path: require the fade-down side to return close to unpressed before reopening.
-    const float down_partial_release_threshold = 1.0f - (margin * 0.5f);
-    // "Deep" means the fade-down side reached near-bottom during the current gesture.
+    // "Bottomed" means the fade-down side reached near-bottom during the current gesture.
     const float down_bottom_threshold       = margin * 0.5f;
-    // After bottoming out, allow reopening much earlier so a small lift can bring audio back.
+    // After bottoming out, ignore further fade-down cuts until the sensor has moved back out of the bottom zone.
     const float down_bottom_release_threshold = margin;
-    bool gate_open                          = s_ui.xf.pair_gate_open[pair->prev_idx];
-    bool fade_down_latched                  = s_ui.xf.pair_fade_down_latched[pair->prev_idx];
-    // Remembers whether this fade-down gesture reached the bottom zone.
-    bool fade_down_bottomed                 = s_ui.xf.pair_fade_down_bottomed[pair->prev_idx];
-    // Masks the normal fade-down press threshold while the sensor is returning after a bottomed reopen.
-    bool fade_down_returning                = s_ui.xf.pair_fade_down_returning[pair->prev_idx];
-    float up_gain                           = compute_xfade_pair_threshold_ramp(fade_up, up_open_threshold, transition_width);
-    float down_gain                         = 0.0f;
-    float output                            = 0.0f;
+    bool bottomed           = s_ui.xf.pair_fade_down_bottomed[pair->prev_idx];
+    float hold_value        = s_ui.xf.pair_hold_value[pair->prev_idx];
+    const float up_gain     = compute_xfade_pair_threshold_ramp(fade_up_raw, up_open_threshold, up_transition_width);
+    const float down_gain   = compute_xfade_pair_threshold_ramp(fade_down, down_press_threshold, transition_width);
+    float output            = hold_value;
 
-    if (!fade_down_latched && !fade_down_returning && fade_down <= down_press_threshold)
+    if (fade_down <= down_bottom_threshold)
     {
-        fade_down_latched  = true;
-        fade_down_bottomed = (fade_down <= down_bottom_threshold);
-    }
-    else if (fade_down_latched)
-    {
-        if (fade_down <= down_bottom_threshold)
-        {
-            fade_down_bottomed = true;
-        }
-
-        // Release the fade-down latch when the sensor has returned far enough:
-        // use the earlier bottomed-release point after a bottom-out press, otherwise
-        // wait until the normal partial-release point near unpressed.
-        if (fade_down >= (fade_down_bottomed ? down_bottom_release_threshold : down_partial_release_threshold))
-        {
-            fade_down_latched   = false;
-            fade_down_returning = fade_down_bottomed;
-            fade_down_bottomed  = false;
-        }
-    }
-    else if (fade_down_returning)
-    {
-        if (fade_down >= down_partial_release_threshold)
-        {
-            fade_down_returning = false;
-        }
-        else if (fade_down <= down_bottom_threshold)
-        {
-            fade_down_latched   = true;
-            fade_down_bottomed  = true;
-            fade_down_returning = false;
-        }
-    }
-
-    if (fade_down_latched)
-    {
-        down_gain = 0.0f;
-    }
-    else if (fade_down_returning)
-    {
-        down_gain = compute_xfade_pair_threshold_ramp(fade_down, down_bottom_release_threshold, transition_width);
+        bottomed   = true;
+        hold_value = 0.0f;
+        output     = 0.0f;
     }
     else
     {
-        down_gain = compute_xfade_pair_threshold_ramp(fade_down, down_press_threshold, transition_width);
+        if (bottomed && (fade_down >= down_bottom_release_threshold))
+        {
+            bottomed = false;
+        }
+
+        if (up_gain > hold_value)
+        {
+            hold_value = up_gain;
+        }
+        if (!bottomed && (down_gain < hold_value))
+        {
+            hold_value = down_gain;
+        }
+
+        output = hold_value;
     }
 
-    output    = up_gain * down_gain;
-    gate_open = (output > 0.0f);
-
-    s_ui.xf.pair_gate_open[pair->prev_idx]           = gate_open;
-    s_ui.xf.pair_fade_down_latched[pair->prev_idx]   = fade_down_latched;
-    s_ui.xf.pair_fade_down_bottomed[pair->prev_idx]  = fade_down_bottomed;
-    s_ui.xf.pair_fade_down_returning[pair->prev_idx] = fade_down_returning;
+    s_ui.xf.pair_gate_open[pair->prev_idx]           = (output > 0.0f);
+    s_ui.xf.pair_hold_value[pair->prev_idx]          = hold_value;
+    s_ui.xf.pair_fade_down_held[pair->prev_idx]      = false;
+    s_ui.xf.pair_fade_down_hold_floor[pair->prev_idx] = 1.0f;
+    s_ui.xf.pair_fade_up_hold_start[pair->prev_idx]   = 0.0f;
+    s_ui.xf.pair_fade_up_hold_rearmed[pair->prev_idx] = false;
+    s_ui.xf.pair_fade_down_latched[pair->prev_idx]   = false;
+    s_ui.xf.pair_fade_down_bottomed[pair->prev_idx]  = bottomed;
+    s_ui.xf.pair_fade_down_returning[pair->prev_idx] = false;
     return output;
 }
 
-// Compute and commit one pair output (A or B) from tracked extrema.
+// Compute and commit one pair output (A or B) from the current fade-up/fade-down drive values.
 static void update_xfade_pair_output(const xfade_pair_runtime_t* pair)
 {
-    // DSP writes are driven by extrema deltas, not raw sample deltas.
-    const float up_now         = s_ui.xf.up_peak[pair->fade_up_idx];
-    const float down_now       = s_ui.xf.down_floor[pair->fade_down_idx];
-    const bool extrema_changed = (fabs(up_now - s_ui.xf.up_peak_prev[pair->prev_idx]) > XFADE_EXTREMA_SEND_THRESHOLD) || (fabs(down_now - s_ui.xf.down_floor_prev[pair->prev_idx]) > XFADE_EXTREMA_SEND_THRESHOLD);
+    const float up_now          = get_xfade_pair_fade_up_raw(pair);
+    const float down_now        = get_xfade_pair_fade_down_raw(pair);
+    const bool drive_changed    = (fabs(up_now - s_ui.xf.up_peak_prev[pair->prev_idx]) > XFADE_EXTREMA_SEND_THRESHOLD) || (fabs(down_now - s_ui.xf.down_floor_prev[pair->prev_idx]) > XFADE_EXTREMA_SEND_THRESHOLD);
 
-    if (extrema_changed)
+    if (drive_changed)
     {
         const float xf      = compute_xfade_pair_value(pair);
         const uint8_t xf_cc = (uint8_t) (xf * 128.0f);
@@ -1834,8 +1827,8 @@ static void apply_xfade_updates(void)
     {
         for (uint32_t i = 0; i < TU_ARRAY_SIZE(s_xfade_pairs); i++)
         {
-            s_ui.xf.up_peak_prev[s_xfade_pairs[i].prev_idx]    = s_ui.xf.up_peak[s_xfade_pairs[i].fade_up_idx];
-            s_ui.xf.down_floor_prev[s_xfade_pairs[i].prev_idx] = s_ui.xf.down_floor[s_xfade_pairs[i].fade_down_idx];
+            s_ui.xf.up_peak_prev[s_xfade_pairs[i].prev_idx]    = get_xfade_pair_fade_up_raw(&s_xfade_pairs[i]);
+            s_ui.xf.down_floor_prev[s_xfade_pairs[i].prev_idx] = get_xfade_pair_fade_down_raw(&s_xfade_pairs[i]);
         }
         s_ui.xf.extrema_prev_valid = true;
     }
@@ -1858,8 +1851,8 @@ void ui_control_reapply_xfade_outputs(void)
 
         pair->set_dc(xf);
         *pair->current_position = xf_cc;
-        s_ui.xf.up_peak_prev[pair->prev_idx]    = s_ui.xf.up_peak[pair->fade_up_idx];
-        s_ui.xf.down_floor_prev[pair->prev_idx] = s_ui.xf.down_floor[pair->fade_down_idx];
+        s_ui.xf.up_peak_prev[pair->prev_idx]    = get_xfade_pair_fade_up_raw(pair);
+        s_ui.xf.down_floor_prev[pair->prev_idx] = get_xfade_pair_fade_down_raw(pair);
     }
 
     s_ui.xf.extrema_prev_valid = true;
@@ -2262,7 +2255,12 @@ void ui_control_reset_state(void)
     {
         s_ui.xf.up_peak_prev[i]             = 0.0f;
         s_ui.xf.down_floor_prev[i]          = 1.0f;
+        s_ui.xf.pair_hold_value[i]          = 0.0f;
+        s_ui.xf.pair_fade_down_hold_floor[i] = 1.0f;
+        s_ui.xf.pair_fade_up_hold_start[i]   = 0.0f;
+        s_ui.xf.pair_fade_up_hold_rearmed[i] = false;
         s_ui.xf.pair_gate_open[i]           = false;
+        s_ui.xf.pair_fade_down_held[i]      = false;
         s_ui.xf.pair_fade_down_latched[i]   = false;
         s_ui.xf.pair_fade_down_bottomed[i]  = false;
         s_ui.xf.pair_fade_down_returning[i] = false;

--- a/STM32CubeIDE/JUMBLEQ/Appli/Core/Src/ui_control.c
+++ b/STM32CubeIDE/JUMBLEQ/Appli/Core/Src/ui_control.c
@@ -79,14 +79,7 @@ typedef struct
     float pair_hold_value[2];  // Current held output value for each xfade pair.
     float up_peak_prev[2];  // Previous fade-up drive value used to detect when pair output needs recomputing.
     float down_floor_prev[2];  // Previous fade-down drive value used to detect when pair output needs recomputing.
-    float pair_fade_down_hold_floor[2];  // Legacy pair scratch value; cleared in the current hold-value model.
-    float pair_fade_up_hold_start[2];  // Legacy pair scratch value; cleared in the current hold-value model.
-    bool pair_fade_up_hold_rearmed[2];  // Legacy pair scratch flag; cleared in the current hold-value model.
-    bool pair_gate_open[2];  // Latest computed nonzero-output flag for each xfade pair.
-    bool pair_fade_down_held[2];  // Legacy pair scratch flag; kept reset in the current hold-value model.
-    bool pair_fade_down_latched[2];  // Legacy pair scratch flag; kept reset in the current hold-value model.
     bool pair_fade_down_bottomed[2];  // Whether each pair is currently in the fade-down bottom zone.
-    bool pair_fade_down_returning[2];  // Legacy pair scratch flag; kept reset in the current hold-value model.
     bool extrema_prev_valid;  // Whether the previous pair-drive snapshots have been initialized.
     uint8_t note_peak_vel[MAG_SW_NUM];  // Peak velocity captured while scanning one xfade sensor note-on edge.
     uint32_t note_scan_start_ms[MAG_SW_NUM];  // Start tick for one xfade sensor note velocity scan window.
@@ -154,18 +147,11 @@ static ui_control_state_t s_ui = {
     .xf.prev                = {1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f},
     .xf.down_floor          = {1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f},
     .xf.up_peak             = {0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f},
-    .xf.pair_hold_value     = {0.0f, 0.0f},
-    .xf.up_peak_prev        = {0.0f, 0.0f},
-    .xf.down_floor_prev     = {1.0f, 1.0f},
-    .xf.pair_fade_down_hold_floor = {1.0f, 1.0f},
-    .xf.pair_fade_up_hold_start   = {0.0f, 0.0f},
-    .xf.pair_fade_up_hold_rearmed = {false, false},
-    .xf.pair_gate_open           = {false, false},
-    .xf.pair_fade_down_held      = {false, false},
-    .xf.pair_fade_down_latched   = {false, false},
+    .xf.pair_hold_value          = {0.0f, 0.0f},
+    .xf.up_peak_prev             = {0.0f, 0.0f},
+    .xf.down_floor_prev          = {1.0f, 1.0f},
     .xf.pair_fade_down_bottomed  = {false, false},
-    .xf.pair_fade_down_returning = {false, false},
-    .xf.extrema_prev_valid  = false,
+    .xf.extrema_prev_valid       = false,
     .is_start_audio_control = false,
 };
 
@@ -1780,15 +1766,8 @@ static float compute_xfade_pair_value(const xfade_pair_runtime_t* pair)
         output = hold_value;
     }
 
-    s_ui.xf.pair_gate_open[pair->prev_idx]           = (output > 0.0f);
-    s_ui.xf.pair_hold_value[pair->prev_idx]          = hold_value;
-    s_ui.xf.pair_fade_down_held[pair->prev_idx]      = false;
-    s_ui.xf.pair_fade_down_hold_floor[pair->prev_idx] = 1.0f;
-    s_ui.xf.pair_fade_up_hold_start[pair->prev_idx]   = 0.0f;
-    s_ui.xf.pair_fade_up_hold_rearmed[pair->prev_idx] = false;
-    s_ui.xf.pair_fade_down_latched[pair->prev_idx]   = false;
-    s_ui.xf.pair_fade_down_bottomed[pair->prev_idx]  = bottomed;
-    s_ui.xf.pair_fade_down_returning[pair->prev_idx] = false;
+    s_ui.xf.pair_hold_value[pair->prev_idx]         = hold_value;
+    s_ui.xf.pair_fade_down_bottomed[pair->prev_idx] = bottomed;
     return output;
 }
 
@@ -2253,17 +2232,10 @@ void ui_control_reset_state(void)
     }
     for (uint8_t i = 0; i < XFADE_PAIR_COUNT; i++)
     {
-        s_ui.xf.up_peak_prev[i]             = 0.0f;
-        s_ui.xf.down_floor_prev[i]          = 1.0f;
-        s_ui.xf.pair_hold_value[i]          = 0.0f;
-        s_ui.xf.pair_fade_down_hold_floor[i] = 1.0f;
-        s_ui.xf.pair_fade_up_hold_start[i]   = 0.0f;
-        s_ui.xf.pair_fade_up_hold_rearmed[i] = false;
-        s_ui.xf.pair_gate_open[i]           = false;
-        s_ui.xf.pair_fade_down_held[i]      = false;
-        s_ui.xf.pair_fade_down_latched[i]   = false;
-        s_ui.xf.pair_fade_down_bottomed[i]  = false;
-        s_ui.xf.pair_fade_down_returning[i] = false;
+        s_ui.xf.up_peak_prev[i]            = 0.0f;
+        s_ui.xf.down_floor_prev[i]         = 1.0f;
+        s_ui.xf.pair_hold_value[i]         = 0.0f;
+        s_ui.xf.pair_fade_down_bottomed[i] = false;
     }
     mark_xfade_cut_margin_dirty();
     s_ui.xf.extrema_prev_valid = false;

--- a/STM32CubeIDE/JUMBLEQ/Appli/Core/Src/ui_control.c
+++ b/STM32CubeIDE/JUMBLEQ/Appli/Core/Src/ui_control.c
@@ -77,10 +77,10 @@ typedef struct
     float down_floor[MAG_SW_NUM];  // Per-sensor held minimum used by paired fade-down tracking.
     float up_peak[MAG_SW_NUM];  // Per-sensor held maximum used by paired fade-up tracking.
     float pair_hold_value[2];  // Current held output value for each xfade pair.
-    float up_peak_prev[2];  // Previous fade-up drive value used to detect when pair output needs recomputing.
-    float down_floor_prev[2];  // Previous fade-down drive value used to detect when pair output needs recomputing.
+    float fade_up_prev[2];  // Previous fade-up value used to detect when pair output needs recomputing.
+    float fade_down_prev[2];  // Previous fade-down value used to detect when pair output needs recomputing.
     bool pair_fade_down_bottomed[2];  // Whether each pair is currently in the fade-down bottom zone.
-    bool extrema_prev_valid;  // Whether the previous pair-drive snapshots have been initialized.
+    bool fade_prev_valid;  // Whether the previous pair fade values have been initialized.
     uint8_t note_peak_vel[MAG_SW_NUM];  // Peak velocity captured while scanning one xfade sensor note-on edge.
     uint32_t note_scan_start_ms[MAG_SW_NUM];  // Start tick for one xfade sensor note velocity scan window.
     bool note_is_on[MAG_SW_NUM];  // Whether each xfade sensor note output is currently on.
@@ -148,10 +148,10 @@ static ui_control_state_t s_ui = {
     .xf.down_floor          = {1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f},
     .xf.up_peak             = {0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f},
     .xf.pair_hold_value          = {0.0f, 0.0f},
-    .xf.up_peak_prev             = {0.0f, 0.0f},
-    .xf.down_floor_prev          = {1.0f, 1.0f},
+    .xf.fade_up_prev             = {0.0f, 0.0f},
+    .xf.fade_down_prev           = {1.0f, 1.0f},
     .xf.pair_fade_down_bottomed  = {false, false},
-    .xf.extrema_prev_valid       = false,
+    .xf.fade_prev_valid          = false,
     .is_start_audio_control = false,
 };
 
@@ -161,7 +161,7 @@ static const uint8_t POT_MAG_CH_LAST  = POT_CH_MAG3;
 
 static const float XFADE_CC_UPDATE_THRESHOLD    = 0.01f;
 static const float XFADE_EXTREMA_HYSTERESIS     = 0.002f;
-static const float XFADE_EXTREMA_SEND_THRESHOLD = 0.002f;
+static const float XFADE_SEND_THRESHOLD         = 0.002f;
 static const float XFADE_PAIR_RESET_THRESHOLD   = 0.98f;
 static const float XFADE_MIN_RESET_CUTOFF       = 0.05f;
 static const float XFADE_PAIR_ONSET_DEADBAND    = 0.05f;
@@ -407,8 +407,8 @@ static void mark_xfade_cut_margin_dirty(void)
 {
     for (uint8_t i = 0; i < XFADE_PAIR_COUNT; i++)
     {
-        s_ui.xf.up_peak_prev[i]    = -1.0f;
-        s_ui.xf.down_floor_prev[i] = -1.0f;
+        s_ui.xf.fade_up_prev[i]   = -1.0f;
+        s_ui.xf.fade_down_prev[i] = -1.0f;
     }
 }
 
@@ -1716,6 +1716,11 @@ static float get_xfade_pair_fade_up_raw(const xfade_pair_runtime_t* pair)
 
 static float compute_xfade_pair_value(const xfade_pair_runtime_t* pair)
 {
+    // Current hold-value model:
+    // - fade-up raises the held output toward its current ramped value
+    // - fade-down lowers the held output toward its current ramped value
+    // - releasing either side leaves the held output where it was
+    // - pushing fade-down into the bottom zone forces the held output to 0
     const float xfade_cut_margin = (pair->prev_idx == XFADE_PAIR_A) ? s_ui.xfade_cut_margin_a : s_ui.xfade_cut_margin_b;
     const float fade_up_raw      = get_xfade_pair_fade_up_raw(pair);
     const float margin           = clamp_xfade_cut_margin(xfade_cut_margin);
@@ -1769,9 +1774,9 @@ static void update_xfade_pair_output(const xfade_pair_runtime_t* pair)
 {
     const float up_now          = get_xfade_pair_fade_up_raw(pair);
     const float down_now        = get_xfade_pair_fade_down_raw(pair);
-    const bool drive_changed    = (fabs(up_now - s_ui.xf.up_peak_prev[pair->prev_idx]) > XFADE_EXTREMA_SEND_THRESHOLD) || (fabs(down_now - s_ui.xf.down_floor_prev[pair->prev_idx]) > XFADE_EXTREMA_SEND_THRESHOLD);
+    const bool fade_changed     = (fabs(up_now - s_ui.xf.fade_up_prev[pair->prev_idx]) > XFADE_SEND_THRESHOLD) || (fabs(down_now - s_ui.xf.fade_down_prev[pair->prev_idx]) > XFADE_SEND_THRESHOLD);
 
-    if (drive_changed)
+    if (fade_changed)
     {
         const float xf      = compute_xfade_pair_value(pair);
         const uint8_t xf_cc = (uint8_t) (xf * 128.0f);
@@ -1783,8 +1788,8 @@ static void update_xfade_pair_output(const xfade_pair_runtime_t* pair)
         }
     }
 
-    s_ui.xf.up_peak_prev[pair->prev_idx]    = up_now;
-    s_ui.xf.down_floor_prev[pair->prev_idx] = down_now;
+    s_ui.xf.fade_up_prev[pair->prev_idx]   = up_now;
+    s_ui.xf.fade_down_prev[pair->prev_idx] = down_now;
 }
 
 // Apply outgoing updates for xfade: MIDI CC stream and DSP DC controls.
@@ -1795,14 +1800,14 @@ static void apply_xfade_updates(void)
         emit_xfade_cc_if_needed((uint8_t) i);
     }
 
-    if (!s_ui.xf.extrema_prev_valid)
+    if (!s_ui.xf.fade_prev_valid)
     {
         for (uint32_t i = 0; i < TU_ARRAY_SIZE(s_xfade_pairs); i++)
         {
-            s_ui.xf.up_peak_prev[s_xfade_pairs[i].prev_idx]    = get_xfade_pair_fade_up_raw(&s_xfade_pairs[i]);
-            s_ui.xf.down_floor_prev[s_xfade_pairs[i].prev_idx] = get_xfade_pair_fade_down_raw(&s_xfade_pairs[i]);
+            s_ui.xf.fade_up_prev[s_xfade_pairs[i].prev_idx]   = get_xfade_pair_fade_up_raw(&s_xfade_pairs[i]);
+            s_ui.xf.fade_down_prev[s_xfade_pairs[i].prev_idx] = get_xfade_pair_fade_down_raw(&s_xfade_pairs[i]);
         }
-        s_ui.xf.extrema_prev_valid = true;
+        s_ui.xf.fade_prev_valid = true;
     }
     else
     {
@@ -1823,11 +1828,11 @@ void ui_control_reapply_xfade_outputs(void)
 
         pair->set_dc(xf);
         *pair->current_position = xf_cc;
-        s_ui.xf.up_peak_prev[pair->prev_idx]    = get_xfade_pair_fade_up_raw(pair);
-        s_ui.xf.down_floor_prev[pair->prev_idx] = get_xfade_pair_fade_down_raw(pair);
+        s_ui.xf.fade_up_prev[pair->prev_idx]   = get_xfade_pair_fade_up_raw(pair);
+        s_ui.xf.fade_down_prev[pair->prev_idx] = get_xfade_pair_fade_down_raw(pair);
     }
 
-    s_ui.xf.extrema_prev_valid = true;
+    s_ui.xf.fade_prev_valid = true;
 }
 
 static void process_mag(void)
@@ -2225,13 +2230,13 @@ void ui_control_reset_state(void)
     }
     for (uint8_t i = 0; i < XFADE_PAIR_COUNT; i++)
     {
-        s_ui.xf.up_peak_prev[i]            = 0.0f;
-        s_ui.xf.down_floor_prev[i]         = 1.0f;
+        s_ui.xf.fade_up_prev[i]           = 0.0f;
+        s_ui.xf.fade_down_prev[i]         = 1.0f;
         s_ui.xf.pair_hold_value[i]         = 0.0f;
         s_ui.xf.pair_fade_down_bottomed[i] = false;
     }
     mark_xfade_cut_margin_dirty();
-    s_ui.xf.extrema_prev_valid = false;
+    s_ui.xf.fade_prev_valid = false;
 
     for (uint16_t i = 0; i < 128U; i++)
     {

--- a/STM32CubeIDE/JUMBLEQ/Appli/Core/Src/ui_control.c
+++ b/STM32CubeIDE/JUMBLEQ/Appli/Core/Src/ui_control.c
@@ -80,6 +80,10 @@ typedef struct
     float pair_bottom_restore_value[2];  // Held output value to restore after leaving the fade-down bottom.
     float fade_up_prev[2];  // Previous fade-up value used to detect when pair output needs recomputing.
     float fade_down_prev[2];  // Previous fade-down value used to detect when pair output needs recomputing.
+    float fade_down_combined_raw[2];  // Per-pair fade-down value after dual-source arbitration.
+    float fade_down_source_prev[2][2];  // Previous fade-down source values used for retrigger detection.
+    uint8_t fade_down_active_source[2];  // Last fade-down source that started a cut gesture.
+    uint8_t fade_down_force_release_reads[2];  // Number of reads that should force a release before retriggering.
     bool pair_fade_down_cut_active[2];  // Whether each pair is inside the current fade-down cut gesture.
     bool pair_bottom_hold_active[2];  // Whether each pair is still forced muted at the bottom of a fade-down gesture.
     bool pair_fade_down_bottomed[2];  // Whether each pair is currently in the fade-down bottom zone.
@@ -154,6 +158,10 @@ static ui_control_state_t s_ui = {
     .xf.pair_bottom_restore_value = {0.0f, 0.0f},
     .xf.fade_up_prev             = {0.0f, 0.0f},
     .xf.fade_down_prev           = {1.0f, 1.0f},
+    .xf.fade_down_combined_raw   = {1.0f, 1.0f},
+    .xf.fade_down_source_prev    = {{1.0f, 1.0f}, {1.0f, 1.0f}},
+    .xf.fade_down_active_source  = {0xFFU, 0xFFU},
+    .xf.fade_down_force_release_reads = {0U, 0U},
     .xf.pair_fade_down_cut_active = {false, false},
     .xf.pair_bottom_hold_active  = {false, false},
     .xf.pair_fade_down_bottomed  = {false, false},
@@ -171,6 +179,8 @@ static const float XFADE_SEND_THRESHOLD         = 0.002f;
 static const float XFADE_PAIR_RESET_THRESHOLD   = 0.98f;
 static const float XFADE_MIN_RESET_CUTOFF       = 0.05f;
 static const float XFADE_PAIR_ONSET_DEADBAND    = 0.05f;
+static const float XFADE_PAIR_FADE_DOWN_PRESS_THRESHOLD     = 0.95f;
+static const float XFADE_PAIR_FADE_DOWN_DEEPER_DELTA        = 0.03f;
 static const float XFADE_PAIR_CUT_MARGIN_MIN    = 0.04f;
 static const float XFADE_PAIR_CUT_MARGIN_MAX    = 0.45f;
 static const float XFADE_PAIR_RAMP_LINEAR_BLEND = 0.60f;
@@ -190,6 +200,10 @@ static const uint8_t MIDI_NOTE_ON_THRESHOLD      = 4U;
 static const uint8_t MIDI_NOTE_OFF_THRESHOLD     = 2U;
 static const uint32_t MIDI_NOTE_VEL_WINDOW_MS    = 12U;
 static const float MIDI_NOTE_VEL_GAMMA           = 0.65f;
+static const uint8_t XFADE_PAIR_A_AUX_FADE_DOWN_IDX = 2U;
+static const uint8_t XFADE_PAIR_B_AUX_FADE_DOWN_IDX = 3U;
+static const uint8_t XFADE_FADE_DOWN_SOURCE_NONE    = 0xFFU;
+static const uint8_t XFADE_FADE_DOWN_RETRIGGER_RELEASE_READS = 8U;
 
 static uint8_t s_note_peak_vel[128];
 static uint32_t s_note_scan_start_ms[128];
@@ -1496,6 +1510,7 @@ static void update_mag_samples(void)
     }
 }
 
+// Lookup for paired xfade endpoints (fade-up side -> fade-down side).
 static int8_t get_pair_fade_down_index_from_up(uint8_t fade_up_idx)
 {
     static const int8_t map[MAG_SW_NUM] = {1, -1, -1, -1, -1, 4};
@@ -1595,7 +1610,7 @@ static void update_xfade_extrema(uint8_t i)
         {
             s_ui.xf.up_peak[i] = pair_raw;
 
-            const int8_t fade_down_idx = get_pair_fade_down_index_from_up((uint8_t) i);
+            const int8_t fade_down_idx = get_pair_fade_down_index_from_up(i);
             if (fade_down_idx >= 0)
             {
                 s_ui.xf.down_floor[(uint8_t) fade_down_idx] = s_ui.xf.up_peak[i];
@@ -1606,7 +1621,7 @@ static void update_xfade_extrema(uint8_t i)
         // This avoids "stuck min" when xfade[0]/xfade[5] remains high and only the paired side moves.
         if (pair_raw >= XFADE_PAIR_RESET_THRESHOLD)
         {
-            const int8_t fade_down_idx = get_pair_fade_down_index_from_up((uint8_t) i);
+            const int8_t fade_down_idx = get_pair_fade_down_index_from_up(i);
             if (fade_down_idx >= 0)
             {
                 s_ui.xf.down_floor[(uint8_t) fade_down_idx] = pair_raw;
@@ -1622,7 +1637,7 @@ static void update_xfade_extrema(uint8_t i)
 
             if (s_ui.xf.down_floor[i] < XFADE_MIN_RESET_CUTOFF)
             {
-                const int8_t fade_up_idx = get_pair_fade_up_index_from_down((uint8_t) i);
+                const int8_t fade_up_idx = get_pair_fade_up_index_from_down(i);
                 if (fade_up_idx >= 0)
                 {
                     s_ui.xf.up_peak[(uint8_t) fade_up_idx] = 0.0f;
@@ -1709,16 +1724,151 @@ static float compute_xfade_pair_threshold_ramp(float value, float threshold, flo
     return (XFADE_PAIR_RAMP_LINEAR_BLEND * t) + ((1.0f - XFADE_PAIR_RAMP_LINEAR_BLEND) * smootherstep);
 }
 
-static float get_xfade_pair_fade_down_raw(const xfade_pair_runtime_t* pair)
+// Fade-down sensors idle near 1.0 and move toward 0.0 when pressed.
+// Keep a small high-end deadband so light touch/noise does not start a cut.
+static float apply_xfade_fade_down_onset_deadband(float raw)
 {
-    return apply_xfade_pair_onset_deadband(pair->fade_down_idx, s_ui.xf.raw[pair->fade_down_idx]);
+    const float high_deadband = 1.0f - XFADE_PAIR_ONSET_DEADBAND;
+
+    raw = clamp01(raw);
+    if (raw >= high_deadband)
+    {
+        return 1.0f;
+    }
+
+    return raw / high_deadband;
 }
 
+// Arbitrate the two fade-down sensors assigned to one xfade pair.
+//
+// source0 is the original fade-down sensor (A:1, B:4), source1 is the
+// auxiliary sensor (A:2, B:3). The active source follows the most recently
+// started cut gesture. When control switches to the other sensor, briefly
+// force fade-down to "released" so repeated flick cuts remain audible even if
+// the previous sensor is still held near the bottom.
+static void update_dual_fade_down_source(uint8_t pair_idx, float source0, float source1)
+{
+    float source[2] = {source0, source1};
+    uint8_t active  = s_ui.xf.fade_down_active_source[pair_idx];
+    uint8_t started = XFADE_FADE_DOWN_SOURCE_NONE;
+    bool force_release = false;
+
+    for (uint8_t i = 0; i < 2U; i++)
+    {
+        const float prev = s_ui.xf.fade_down_source_prev[pair_idx][i];
+        // Detect a new cut either from the idle zone or from a clear deeper
+        // push on the non-active sensor.
+        const bool newly_pressed = (prev >= XFADE_PAIR_FADE_DOWN_PRESS_THRESHOLD) &&
+                                   (source[i] < XFADE_PAIR_FADE_DOWN_PRESS_THRESHOLD);
+        const bool other_pressed_deeper = (i != active) &&
+                                          (source[i] < XFADE_PAIR_RESET_THRESHOLD) &&
+                                          ((prev - source[i]) >= XFADE_PAIR_FADE_DOWN_DEEPER_DELTA);
+
+        if (newly_pressed || other_pressed_deeper)
+        {
+            started = i;
+        }
+    }
+
+    if (started != XFADE_FADE_DOWN_SOURCE_NONE)
+    {
+        if ((active != XFADE_FADE_DOWN_SOURCE_NONE) && (started != active))
+        {
+            // Switching sources while the previous one is bottomed would
+            // otherwise keep the audio muted and hide the second cut.
+            if (s_ui.xf.pair_bottom_restore_value[pair_idx] > s_ui.xf.pair_hold_value[pair_idx])
+            {
+                s_ui.xf.pair_hold_value[pair_idx] = s_ui.xf.pair_bottom_restore_value[pair_idx];
+            }
+            s_ui.xf.pair_fade_down_cut_active[pair_idx] = false;
+            s_ui.xf.pair_bottom_hold_active[pair_idx] = false;
+            s_ui.xf.pair_fade_down_bottomed[pair_idx] = false;
+            s_ui.xf.fade_down_force_release_reads[pair_idx] = XFADE_FADE_DOWN_RETRIGGER_RELEASE_READS;
+        }
+        active = started;
+    }
+
+    // Once both fade-down sensors are released, the next press can claim
+    // ownership without being treated as a source switch.
+    if ((source[0] >= XFADE_PAIR_RESET_THRESHOLD) && (source[1] >= XFADE_PAIR_RESET_THRESHOLD))
+    {
+        active = XFADE_FADE_DOWN_SOURCE_NONE;
+    }
+
+    s_ui.xf.fade_down_active_source[pair_idx] = active;
+    s_ui.xf.fade_down_source_prev[pair_idx][0] = source[0];
+    s_ui.xf.fade_down_source_prev[pair_idx][1] = source[1];
+
+    force_release = (s_ui.xf.fade_down_force_release_reads[pair_idx] > 0U);
+    if (force_release)
+    {
+        // Emit a short "released" window before applying the newly active
+        // source. This creates the audible return between rapid cuts.
+        s_ui.xf.fade_down_force_release_reads[pair_idx]--;
+        s_ui.xf.fade_down_combined_raw[pair_idx] = 1.0f;
+        return;
+    }
+
+    if (active != XFADE_FADE_DOWN_SOURCE_NONE)
+    {
+        // During a gesture, only the active source drives fade-down. This lets
+        // the other sensor retrigger even if the first one remains deeper.
+        s_ui.xf.fade_down_combined_raw[pair_idx] = source[active];
+        return;
+    }
+
+    // Idle/fallback behavior: behave like the old dual-input minimum.
+    s_ui.xf.fade_down_combined_raw[pair_idx] = (source[0] < source[1]) ? source[0] : source[1];
+}
+
+// Convert each pair's physical fade-down sensor(s) into one cached value.
+// This is done once per xfade scan so retrigger state is not consumed by
+// multiple later reads of get_xfade_pair_fade_down_raw().
+static void update_xfade_pair_fade_down_source(const xfade_pair_runtime_t* pair)
+{
+    float mag_raw = apply_xfade_pair_onset_deadband(pair->fade_down_idx, s_ui.xf.raw[pair->fade_down_idx]);
+
+    if (pair->prev_idx == XFADE_PAIR_A)
+    {
+        const float aux_raw = apply_xfade_fade_down_onset_deadband(s_ui.xf.raw[XFADE_PAIR_A_AUX_FADE_DOWN_IDX]);
+        update_dual_fade_down_source(pair->prev_idx, mag_raw, aux_raw);
+        return;
+    }
+    else if (pair->prev_idx == XFADE_PAIR_B)
+    {
+        const float aux_raw = apply_xfade_fade_down_onset_deadband(s_ui.xf.raw[XFADE_PAIR_B_AUX_FADE_DOWN_IDX]);
+        update_dual_fade_down_source(pair->prev_idx, mag_raw, aux_raw);
+        return;
+    }
+
+    s_ui.xf.fade_down_combined_raw[pair->prev_idx] = mag_raw;
+}
+
+static void update_xfade_fade_down_sources(void)
+{
+    for (uint32_t i = 0; i < TU_ARRAY_SIZE(s_xfade_pairs); i++)
+    {
+        update_xfade_pair_fade_down_source(&s_xfade_pairs[i]);
+    }
+}
+
+static float get_xfade_pair_fade_down_raw(const xfade_pair_runtime_t* pair)
+{
+    return s_ui.xf.fade_down_combined_raw[pair->prev_idx];
+}
+
+// Fade-up sensors idle near 0.0 and rise toward 1.0 when pressed.
 static float get_xfade_pair_fade_up_raw(const xfade_pair_runtime_t* pair)
 {
     return apply_xfade_pair_onset_deadband(pair->fade_up_idx, s_ui.xf.raw[pair->fade_up_idx]);
 }
 
+// Update the held output value for one xfade pair.
+//
+// The output is not a direct mix of sensors. Fade-up can raise the held value,
+// fade-down can lower it, and releasing either side leaves the output where it
+// was. A full fade-down press enters a bottom-hold state so the cut stays muted
+// until the sensor leaves the bottom zone.
 static float compute_xfade_pair_value(const xfade_pair_runtime_t* pair)
 {
     // Current hold-value model:
@@ -1749,12 +1899,15 @@ static float compute_xfade_pair_value(const xfade_pair_runtime_t* pair)
     const float up_gain     = compute_xfade_pair_threshold_ramp(fade_up, up_open_threshold, margin);
     const float down_gain   = compute_xfade_pair_threshold_ramp(fade_down, down_press_threshold, margin);
 
+    // Capture the value to restore if this fade-down gesture reaches bottom.
     if (!cut_active && (fade_down <= down_press_threshold))
     {
         cut_active    = true;
         restore_value = hold_value;
     }
 
+    // Bottom entry is a hard cut. The restore value is kept separately so a
+    // retrigger or bottom release can bring the sound back before the next cut.
     if (!bottomed && (fade_down <= down_bottom_threshold))
     {
         bottomed           = true;
@@ -1765,6 +1918,7 @@ static float compute_xfade_pair_value(const xfade_pair_runtime_t* pair)
 
     if (bottom_hold_active)
     {
+        // Keep output muted while the sensor remains very close to the bottom.
         if (!bottom_entered && (fade_down >= down_bottom_hold_release_threshold))
         {
             bottom_hold_active = false;
@@ -1780,12 +1934,14 @@ static float compute_xfade_pair_value(const xfade_pair_runtime_t* pair)
     }
     else if (bottomed && (fade_down <= down_bottom_rehold_threshold))
     {
+        // If a bottomed gesture dips back into the bottom zone, mute again.
         bottom_hold_active = true;
         hold_value         = 0.0f;
     }
 
     if (!bottom_hold_active)
     {
+        // Fully releasing fade-down arms the next normal cut gesture.
         if (bottomed && (fade_down >= down_bottom_release_threshold))
         {
             bottomed           = false;
@@ -1797,6 +1953,7 @@ static float compute_xfade_pair_value(const xfade_pair_runtime_t* pair)
         {
             hold_value = up_gain;
         }
+        // Fade-down can only reduce the held value during a non-bottomed cut.
         if (!bottomed && (down_gain < hold_value))
         {
             hold_value = down_gain;
@@ -1837,6 +1994,8 @@ static void update_xfade_pair_output(const xfade_pair_runtime_t* pair)
 // Apply outgoing updates for xfade: MIDI CC stream and DSP DC controls.
 static void apply_xfade_updates(void)
 {
+    update_xfade_fade_down_sources();
+
     for (uint32_t i = 0; i < MAG_SW_NUM; i++)
     {
         emit_xfade_cc_if_needed((uint8_t) i);
@@ -1862,6 +2021,8 @@ static void apply_xfade_updates(void)
 
 void ui_control_reapply_xfade_outputs(void)
 {
+    update_xfade_fade_down_sources();
+
     for (uint32_t i = 0; i < TU_ARRAY_SIZE(s_xfade_pairs); i++)
     {
         const xfade_pair_runtime_t* pair = &s_xfade_pairs[i];
@@ -2274,6 +2435,11 @@ void ui_control_reset_state(void)
     {
         s_ui.xf.fade_up_prev[i]           = 0.0f;
         s_ui.xf.fade_down_prev[i]         = 1.0f;
+        s_ui.xf.fade_down_combined_raw[i] = 1.0f;
+        s_ui.xf.fade_down_source_prev[i][0] = 1.0f;
+        s_ui.xf.fade_down_source_prev[i][1] = 1.0f;
+        s_ui.xf.fade_down_active_source[i] = XFADE_FADE_DOWN_SOURCE_NONE;
+        s_ui.xf.fade_down_force_release_reads[i] = 0U;
         s_ui.xf.pair_hold_value[i]         = 0.0f;
         s_ui.xf.pair_bottom_restore_value[i] = 0.0f;
         s_ui.xf.pair_fade_down_cut_active[i] = false;

--- a/STM32CubeIDE/JUMBLEQ/Appli/Core/Src/ui_control.c
+++ b/STM32CubeIDE/JUMBLEQ/Appli/Core/Src/ui_control.c
@@ -1689,11 +1689,6 @@ static float clamp01(float value)
     return value;
 }
 
-static float compute_xfade_pair_transition_width(float margin)
-{
-    return margin;
-}
-
 static float compute_xfade_pair_threshold_ramp(float value, float threshold, float width)
 {
     float t;
@@ -1725,10 +1720,8 @@ static float compute_xfade_pair_value(const xfade_pair_runtime_t* pair)
     const float fade_up_raw      = get_xfade_pair_fade_up_raw(pair);
     const float margin           = clamp_xfade_cut_margin(xfade_cut_margin);
     const float fade_down        = get_xfade_pair_fade_down_raw(pair);
-    const float transition_width = compute_xfade_pair_transition_width(margin);
     // fade-up opens across the first margin-wide slice of travel after onset deadband.
     const float up_open_threshold             = 0.0f;
-    const float up_transition_width           = margin;
     // fade-down starts cutting once the sensor moves this far from its unpressed (1.0) position.
     const float down_press_threshold           = 1.0f - margin;
     // "Bottomed" means the fade-down side reached near-bottom during the current gesture.
@@ -1737,8 +1730,8 @@ static float compute_xfade_pair_value(const xfade_pair_runtime_t* pair)
     const float down_bottom_release_threshold = margin;
     bool bottomed           = s_ui.xf.pair_fade_down_bottomed[pair->prev_idx];
     float hold_value        = s_ui.xf.pair_hold_value[pair->prev_idx];
-    const float up_gain     = compute_xfade_pair_threshold_ramp(fade_up_raw, up_open_threshold, up_transition_width);
-    const float down_gain   = compute_xfade_pair_threshold_ramp(fade_down, down_press_threshold, transition_width);
+    const float up_gain     = compute_xfade_pair_threshold_ramp(fade_up_raw, up_open_threshold, margin);
+    const float down_gain   = compute_xfade_pair_threshold_ramp(fade_down, down_press_threshold, margin);
     float output            = hold_value;
 
     if (fade_down <= down_bottom_threshold)


### PR DESCRIPTION
- xfade A/B の fade-down に補助磁気スイッチを追加
- 2つの fade-down スイッチを連続操作した際に、後から押したスイッチへ主導権を切り替える処理を追加
- 主導権切り替え時に短い復帰区間を挟み、細かいカットが聞こえやすくなるよう調整
- xfade 処理周辺のコメントと定数名を整理