### PR TITLE
fade-up押下時の強制リリース時間を延長

### DIFF
--- a/STM32CubeIDE/JUMBLEQ/Appli/Core/Src/ui_control.c
+++ b/STM32CubeIDE/JUMBLEQ/Appli/Core/Src/ui_control.c
@@ -227,7 +227,7 @@ static const uint8_t MIDI_NOTE_OFF_THRESHOLD     = 2U;
 static const uint32_t MIDI_NOTE_VEL_WINDOW_MS    = 12U;
 static const float MIDI_NOTE_VEL_GAMMA           = 0.65f;
 static const uint8_t XFADE_FADE_DOWN_SOURCE_NONE    = 0xFFU;
-static const uint8_t XFADE_FADE_DOWN_RETRIGGER_RELEASE_READS_WITH_FADE_UP = 8U;
+static const uint8_t XFADE_FADE_DOWN_RETRIGGER_RELEASE_READS_WITH_FADE_UP = 16U;
 static const uint8_t XFADE_FADE_DOWN_RETRIGGER_RELEASE_READS_MOMENTARY    = 16U;
 
 static uint8_t s_note_peak_vel[128];


### PR DESCRIPTION
fade-up押下中にメイン／補助fade-downを切り替えた際の強制リリース回数を、8回から16回へ変更する。

強制リリース時間を約16msから約32msへ延長し、再トリガー時の音の切れ方を明確にする。

モーメンタリー時の強制リリース回数は16回のまま維持する。
