### PR TITLE
SENDルーティングでのUSBオーディオループバックを防止

### DIFF
--- a/STM32CubeIDE/JUMBLEQ/Appli/Core/Inc/adau1466.h
+++ b/STM32CubeIDE/JUMBLEQ/Appli/Core/Inc/adau1466.h
@@ -102,6 +102,7 @@ void control_hp_out_gain(const uint16_t adc_val);
 
 void select_input_type(uint8_t ch, uint8_t type);
 void enable_dvs(uint8_t ch, bool enable);
+void select_send_source(uint8_t ch, bool select_dvs);
 
 void select_xf_assignA_source(uint8_t ch);
 void select_xf_assignB_source(uint8_t ch);

--- a/STM32CubeIDE/JUMBLEQ/Appli/Core/Src/adau1466.c
+++ b/STM32CubeIDE/JUMBLEQ/Appli/Core/Src/adau1466.c
@@ -579,9 +579,9 @@ void enable_ch1_dvs()
     (void) adau1466_safeload_write_words(MOD_DVS_SW_1_INDEX_CHANNEL0_ADDR, MOD_DVS_SW_1_INDEX_CHANNEL0_MEM_PAGE, safeload_data, 2U);
 }
 
-void select_send_ch1_src(bool enable)
+static void select_send_ch1_src(bool select_dvs)
 {
-    ADI_REG_TYPE Mode0_0[4] = {0x00, 0x00, 0x00, enable ? 0x01 : 0x00};
+    ADI_REG_TYPE Mode0_0[4] = {0x00, 0x00, 0x00, select_dvs ? 0x01 : 0x00};
 
     SIGMA_WRITE_REGISTER_BLOCK_IT(DEVICE_ADDR_ADAU146XSCHEMATIC_1, MOD_SEND_SW_1_INDEX_ADDR, 4, Mode0_0);
 }
@@ -608,11 +608,23 @@ void enable_ch2_dvs()
     (void) adau1466_safeload_write_words(MOD_DVS_SW_2_INDEX_CHANNEL0_ADDR, MOD_DVS_SW_2_INDEX_CHANNEL0_MEM_PAGE, safeload_data, 2U);
 }
 
-void select_send_ch2_src(bool enable)
+static void select_send_ch2_src(bool select_dvs)
 {
-    ADI_REG_TYPE Mode0_0[4] = {0x00, 0x00, 0x00, enable ? 0x01 : 0x00};
+    ADI_REG_TYPE Mode0_0[4] = {0x00, 0x00, 0x00, select_dvs ? 0x01 : 0x00};
 
     SIGMA_WRITE_REGISTER_BLOCK_IT(DEVICE_ADDR_ADAU146XSCHEMATIC_1, MOD_SEND_SW_2_INDEX_ADDR, 4, Mode0_0);
+}
+
+void select_send_source(uint8_t ch, bool select_dvs)
+{
+    if (ch == INPUT_CH1)
+    {
+        select_send_ch1_src(select_dvs);
+    }
+    else if (ch == INPUT_CH2)
+    {
+        select_send_ch2_src(select_dvs);
+    }
 }
 
 void enable_dvs(uint8_t ch, bool enable)
@@ -627,7 +639,6 @@ void enable_dvs(uint8_t ch, bool enable)
         {
             disable_ch1_dvs();
         }
-        select_send_ch1_src(enable);
     }
     else if (ch == INPUT_CH2)
     {
@@ -639,7 +650,6 @@ void enable_dvs(uint8_t ch, bool enable)
         {
             disable_ch2_dvs();
         }
-        select_send_ch2_src(enable);
     }
 }
 

--- a/STM32CubeIDE/JUMBLEQ/Appli/Core/Src/ui_control.c
+++ b/STM32CubeIDE/JUMBLEQ/Appli/Core/Src/ui_control.c
@@ -995,16 +995,37 @@ static void apply_input_type_change(uint8_t input_ch, uint8_t input_type)
     replace_assign_for_input_channel(&s_ui.current_xfpost_assign, input_ch, new_src);
 }
 
+static bool is_usb_assign(uint8_t assign)
+{
+    return (assign == INPUT_SRC_USB12) || (assign == INPUT_SRC_USB34);
+}
+
+static void apply_send_source_selection(uint8_t input_ch)
+{
+    if (input_ch == INPUT_CH1)
+    {
+        const bool select_dvs = (s_ui.current_ch1_dvs_enable != 0U) || is_usb_assign(s_ui.current_xfA_assign);
+        select_send_source(INPUT_CH1, select_dvs);
+    }
+    else if (input_ch == INPUT_CH2)
+    {
+        const bool select_dvs = (s_ui.current_ch2_dvs_enable != 0U) || is_usb_assign(s_ui.current_xfB_assign);
+        select_send_source(INPUT_CH2, select_dvs);
+    }
+}
+
 static void apply_xf_assign_a(uint8_t input_ch)
 {
     select_xf_assignA_source(input_ch);
     s_ui.current_xfA_assign = current_input_src_from_channel(input_ch);
+    apply_send_source_selection(INPUT_CH1);
 }
 
 static void apply_xf_assign_b(uint8_t input_ch)
 {
     select_xf_assignB_source(input_ch);
     s_ui.current_xfB_assign = current_input_src_from_channel(input_ch);
+    apply_send_source_selection(INPUT_CH2);
 }
 
 static void apply_xf_assign_post(uint8_t input_ch)
@@ -1041,6 +1062,7 @@ static void apply_dvs_state(uint8_t input_ch, bool enable)
     {
         s_ui.current_ch2_dvs_enable = enable ? 1U : 0U;
     }
+    apply_send_source_selection(input_ch);
 }
 
 static bool assign_to_input_ch(uint8_t assign, uint8_t* input_ch)


### PR DESCRIPTION
XF A/BにUSBが割り当てられている場合は、DVSが無効でもSEND出力をDVS側へ切り替える。XF割り当てまたはDVS状態の変更時にSENDのルーティングを再評価する。
